### PR TITLE
Release jdemetra '0.0.7'

### DIFF
--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for JDemetra+ with noVNC setup
 type: application
 
 # Version of the chart
-version: 0.0.7-alpha.1
+version: 0.0.7
 
 # Version of the application
 appVersion: "2.2.4"


### PR DESCRIPTION
release as '0.0.7' to allow the service to be visible after update to onyxia that filters unstable versions.