### PR TITLE
Bump versions

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.28
+version: 1.9.28
 
 dependencies:
   - name: library-chart

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -390,7 +390,7 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/datadoc/values.schema.json
+++ b/charts/datadoc/values.schema.json
@@ -390,7 +390,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/doom/Chart.yaml
+++ b/charts/doom/Chart.yaml
@@ -4,7 +4,7 @@ description: Swap algorithms for ammo and scatter plots for shotguns in the ulti
 type: application
 
 # Version of the chart
-version: 0.3.5
+version: 1.3.5
 
 # Version of the application
 appVersion: "1.0.0"

--- a/charts/doom/values.schema.json
+++ b/charts/doom/values.schema.json
@@ -288,13 +288,9 @@
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/doom/values.schema.json
+++ b/charts/doom/values.schema.json
@@ -290,7 +290,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/jdemetra-experimental/Chart.yaml
+++ b/charts/jdemetra-experimental/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 2.0.3
 
 dependencies:
   - name: library-chart

--- a/charts/jdemetra-experimental/values.schema.json
+++ b/charts/jdemetra-experimental/values.schema.json
@@ -458,13 +458,9 @@
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/jdemetra-experimental/values.schema.json
+++ b/charts/jdemetra-experimental/values.schema.json
@@ -460,7 +460,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/jdemetra-new/Chart.yaml
+++ b/charts/jdemetra-new/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 1.1.9
 
 dependencies:
   - name: library-chart

--- a/charts/jdemetra-new/values.schema.json
+++ b/charts/jdemetra-new/values.schema.json
@@ -458,13 +458,9 @@
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/jdemetra-new/values.schema.json
+++ b/charts/jdemetra-new/values.schema.json
@@ -460,7 +460,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -4,7 +4,7 @@ description: JDemetra+ offers seasonal adjustment and time series analysis with 
 type: application
 
 # Version of the chart
-version: 0.5.5
+version: 1.5.5
 
 # Version of the application
 appVersion: "3.2.1"

--- a/charts/jdemetra/values.schema.json
+++ b/charts/jdemetra/values.schema.json
@@ -288,13 +288,9 @@
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/jdemetra/values.schema.json
+++ b/charts/jdemetra/values.schema.json
@@ -290,7 +290,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/jupyter-dapla-suspend/Chart.yaml
+++ b/charts/jupyter-dapla-suspend/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.6
+version: 2.6.6
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-dapla-suspend/values.schema.json
+++ b/charts/jupyter-dapla-suspend/values.schema.json
@@ -541,7 +541,8 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteSchemaWith": "nodeSelector.json"
+                "overwriteSchemaWith": "nodeSelector.json",
+                "overwriteDefaultWith": "region.nodeSelector"
             }
         },
       "oidc": {

--- a/charts/jupyter-dapla-suspend/values.schema.json
+++ b/charts/jupyter-dapla-suspend/values.schema.json
@@ -541,7 +541,7 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteDefaultWith": "region.nodeSelector"
+                "overwriteSchemaWith": "nodeSelector.json"
             }
         },
       "oidc": {

--- a/charts/jupyter-kenneth/Chart.yaml
+++ b/charts/jupyter-kenneth/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.17
+version: 1.3.17
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-kenneth/values.schema.json
+++ b/charts/jupyter-kenneth/values.schema.json
@@ -588,7 +588,7 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteDefaultWith": "region.nodeSelector"
+                "overwriteSchemaWith": "nodeSelector.json"
             }
         },
       "oidc": {

--- a/charts/jupyter-kenneth/values.schema.json
+++ b/charts/jupyter-kenneth/values.schema.json
@@ -588,7 +588,8 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteSchemaWith": "nodeSelector.json"
+                "overwriteSchemaWith": "nodeSelector.json",
+                "overwriteDefaultWith": "region.nodeSelector"
             }
         },
       "oidc": {

--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.21
+version: 1.3.21
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-playground/values.schema.json
+++ b/charts/jupyter-playground/values.schema.json
@@ -544,7 +544,7 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteDefaultWith": "region.nodeSelector"
+                "overwriteSchemaWith": "nodeSelector.json"
             }
         },
         "oidc": {

--- a/charts/jupyter-playground/values.schema.json
+++ b/charts/jupyter-playground/values.schema.json
@@ -544,7 +544,8 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteSchemaWith": "nodeSelector.json"
+                "overwriteSchemaWith": "nodeSelector.json",
+                "overwriteDefaultWith": "region.nodeSelector"
             }
         },
         "oidc": {

--- a/charts/jupyter-rpk/Chart.yaml
+++ b/charts/jupyter-rpk/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.4
+version: 1.5.4
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-rpk/values.schema.json
+++ b/charts/jupyter-rpk/values.schema.json
@@ -595,7 +595,7 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteDefaultWith": "region.nodeSelector"
+                "overwriteSchemaWith": "nodeSelector.json"
             }
         },
       "oidc": {

--- a/charts/jupyter-rpk/values.schema.json
+++ b/charts/jupyter-rpk/values.schema.json
@@ -595,7 +595,8 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteSchemaWith": "nodeSelector.json"
+                "overwriteSchemaWith": "nodeSelector.json",
+                "overwriteDefaultWith": "region.nodeSelector"
             }
         },
       "oidc": {

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.49
+version: 1.3.49
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -580,7 +580,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -580,7 +580,7 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/klassr_tutorial/Chart.yaml
+++ b/charts/klassr_tutorial/Chart.yaml
@@ -4,7 +4,7 @@ description: An example Tutorial application for KLASS using R. Example on how y
 type: application
 
 # Version of the chart
-version: 0.3.4
+version: 1.3.4
 
 # Version of the application
 appVersion: "1.0.0"

--- a/charts/klassr_tutorial/values.schema.json
+++ b/charts/klassr_tutorial/values.schema.json
@@ -288,13 +288,9 @@
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/klassr_tutorial/values.schema.json
+++ b/charts/klassr_tutorial/values.schema.json
@@ -290,7 +290,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/qgis/Chart.yaml
+++ b/charts/qgis/Chart.yaml
@@ -3,7 +3,7 @@ name: qgis
 description: QGIS Desktop - Open-source GIS software for geospatial data management, mapping, and analysis. User-friendly interface, versatile tools, and ideal for all skill levels.
 type: application
 
-version: 0.12.3
+version: 1.12.3
 
 # Version of the application
 appVersion: "3.34.3"

--- a/charts/qgis/values.schema.json
+++ b/charts/qgis/values.schema.json
@@ -288,13 +288,9 @@
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/qgis/values.schema.json
+++ b/charts/qgis/values.schema.json
@@ -290,7 +290,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.12
+version: 1.3.12
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -562,7 +562,8 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteSchemaWith": "nodeSelector.json"
+                "overwriteSchemaWith": "nodeSelector.json",
+                "overwriteDefaultWith": "region.nodeSelector"
             }
         },
         "oidc": {

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -562,7 +562,7 @@
             "default": {},
             "x-onyxia": {
                 "hidden": true,
-                "overwriteDefaultWith": "region.nodeSelector"
+                "overwriteSchemaWith": "nodeSelector.json"
             }
         },
         "oidc": {

--- a/charts/sirius-editering/Chart.yaml
+++ b/charts/sirius-editering/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 1.3.5
 dependencies:
   - name: library-chart
     version: 3.2.4

--- a/charts/sirius-editering/values.schema.json
+++ b/charts/sirius-editering/values.schema.json
@@ -396,7 +396,7 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/sirius-editering/values.schema.json
+++ b/charts/sirius-editering/values.schema.json
@@ -396,7 +396,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/vscode-python-buckets/Chart.yaml
+++ b/charts/vscode-python-buckets/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.13
+version: 3.9.13
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python-buckets/values.schema.json
+++ b/charts/vscode-python-buckets/values.schema.json
@@ -605,30 +605,13 @@
         "overwriteDefaultWith": "region.startupProbe"
       }
     },
-    "tolerations": {
-      "type": "array",
-      "description": "Array of tolerations",
-      "default": [],
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.tolerations}}"
-      },
-      "x-onyxia": {
-        "hidden": true,
-        "overwriteDefaultWith": "region.tolerations"
-      }
-    },
     "nodeSelector": {
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/vscode-python-buckets/values.schema.json
+++ b/charts/vscode-python-buckets/values.schema.json
@@ -611,7 +611,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/vscode-python-suspend/Chart.yaml
+++ b/charts/vscode-python-suspend/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.29
+version: 1.5.29
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python-suspend/values.schema.json
+++ b/charts/vscode-python-suspend/values.schema.json
@@ -630,7 +630,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {

--- a/charts/vscode-python-suspend/values.schema.json
+++ b/charts/vscode-python-suspend/values.schema.json
@@ -628,13 +628,9 @@
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.13
+version: 1.3.13
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -671,13 +671,9 @@
       "type": "object",
       "description": "NodeSelector",
       "default": {},
-      "x-form": {
-        "hidden": true,
-        "value": "{{region.nodeSelector}}"
-      },
       "x-onyxia": {
         "hidden": true,
-        "overwriteDefaultWith": "region.nodeSelector"
+        "overwriteSchemaWith": "nodeSelector.json"
       }
     },
     "oidc": {

--- a/charts/vscode-python/values.schema.json
+++ b/charts/vscode-python/values.schema.json
@@ -673,7 +673,8 @@
       "default": {},
       "x-onyxia": {
         "hidden": true,
-        "overwriteSchemaWith": "nodeSelector.json"
+        "overwriteSchemaWith": "nodeSelector.json",
+        "overwriteDefaultWith": "region.nodeSelector"
       }
     },
     "oidc": {


### PR DESCRIPTION
There is break change with migration of onyxia from v8 to v9. "defaultConfiguration" in region configuration is not allowed anymore and has been replaced by JSONSchemas override using the new api.schemas key from v9 helm chart. Chart owners can now define which properties can be overridden using a JSON Schema.

In v9, overwriteDefaultWith has been replaced by overwriteSchemaWith, which offers more flexibility due to the capabilities of JSON Schemas.

These changes should applied after onyxia has been upgraded to v9.

Internal ref: [DPSKY-818]

[DPSKY-818]: https://statistics-norway.atlassian.net/browse/DPSKY-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ