### PR TITLE
Bump major verisons for all charts

### DIFF
--- a/charts/datadoc/Chart.yaml
+++ b/charts/datadoc/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.29
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/doom/Chart.yaml
+++ b/charts/doom/Chart.yaml
@@ -4,7 +4,7 @@ description: Swap algorithms for ammo and scatter plots for shotguns in the ulti
 type: application
 
 # Version of the chart
-version: 1.3.6
+version: 2.0.0
 
 # Version of the application
 appVersion: "1.0.0"

--- a/charts/jdemetra-experimental/Chart.yaml
+++ b/charts/jdemetra-experimental/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 2.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/jdemetra-new/Chart.yaml
+++ b/charts/jdemetra-new/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/jdemetra/Chart.yaml
+++ b/charts/jdemetra/Chart.yaml
@@ -4,7 +4,7 @@ description: JDemetra+ offers seasonal adjustment and time series analysis with 
 type: application
 
 # Version of the chart
-version: 0.5.5
+version: 1.0.0
 
 # Version of the application
 appVersion: "3.2.1"

--- a/charts/jupyter-dapla-suspend/Chart.yaml
+++ b/charts/jupyter-dapla-suspend/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.6
+version: 2.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-kenneth/Chart.yaml
+++ b/charts/jupyter-kenneth/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.17
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-playground/Chart.yaml
+++ b/charts/jupyter-playground/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.21
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter-rpk/Chart.yaml
+++ b/charts/jupyter-rpk/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.4
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.49
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/ki-chatbot/Chart.yaml
+++ b/charts/ki-chatbot/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/klassr_tutorial/Chart.yaml
+++ b/charts/klassr_tutorial/Chart.yaml
@@ -4,7 +4,7 @@ description: An example Tutorial application for KLASS using R. Example on how y
 type: application
 
 # Version of the chart
-version: 0.3.4
+version: 1.0.0
 
 # Version of the application
 appVersion: "1.0.0"

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 
 type: application
 
-version: 0.0.3
+version: 1.0.0
 
 dependencies:
   - name: postgresql

--- a/charts/qgis/Chart.yaml
+++ b/charts/qgis/Chart.yaml
@@ -3,7 +3,7 @@ name: qgis
 description: QGIS Desktop - Open-source GIS software for geospatial data management, mapping, and analysis. User-friendly interface, versatile tools, and ideal for all skill levels.
 type: application
 
-version: 0.12.3
+version: 1.0.0
 
 # Version of the application
 appVersion: "3.34.3"

--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.12
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/sirius-editering/Chart.yaml
+++ b/charts/sirius-editering/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 1.0.0
 dependencies:
   - name: library-chart
     version: 3.2.4

--- a/charts/vscode-python-buckets/Chart.yaml
+++ b/charts/vscode-python-buckets/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.13
+version: 3.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python-suspend/Chart.yaml
+++ b/charts/vscode-python-suspend/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.29
+version: 1.0.0
 
 dependencies:
   - name: library-chart

--- a/charts/vscode-python/Chart.yaml
+++ b/charts/vscode-python/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.14
+version: 2.0.0
 
 dependencies:
   - name: library-chart


### PR DESCRIPTION
after bug introduced in 173d7ad79e098020bfcad27a85ed8dc8e9f87d2e where versions was rolled back, thus leading to artifacts on github existing and thus faliing pipelines. This remedies this by bumping all chart to a new major version