### PR TITLE
Bump qgis version such that it is shown in the gui

### DIFF
--- a/charts/qgis/Chart.yaml
+++ b/charts/qgis/Chart.yaml
@@ -3,7 +3,7 @@ name: qgis
 description: QGIS Desktop - Open-source GIS software for geospatial data management, mapping, and analysis. User-friendly interface, versatile tools, and ideal for all skill levels.
 type: application
 
-version: 1.0.0
+version: 1.13.0
 
 # Version of the application
 appVersion: "3.34.3"

--- a/charts/qgis/values.yaml
+++ b/charts/qgis/values.yaml
@@ -18,7 +18,7 @@ security:
       - "ssb.no"
   oauth2:
     provider: keycloak-oidc
-    oidcIssuerUrl: ""
+    oidcIssuerUrl: "placeholder"
     clientId: "my-client"
     authenticatedEmails: ""
 oidc:


### PR DESCRIPTION
As 1.12.3 is the 'latest' release, even though it is not