### PR TITLE
Add prodcom service chart

### DIFF
--- a/charts/prodcom/.helmignore
+++ b/charts/prodcom/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/prodcom/Chart.yaml
+++ b/charts/prodcom/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: prodcom
+description: Prodcom – SSBs saksbehandlingsløsning for industriell vareproduksjon (Plotly Dash-app).
+icon: https://cdn-icons-png.flaticon.com/512/2933/2933116.png
+keywords:
+  - Prodcom
+  - Dash
+  - Python
+  - Industri
+  - Strukturstatistikk
+home: https://github.com/statisticsnorway/stat-prodcom
+sources:
+  - https://github.com/statisticsnorway/stat-prodcom
+  - https://github.com/statisticsnorway/dapla-lab-helm-charts-experimental
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+dependencies:
+  - name: library-chart
+    version: 4.6.1
+    repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/prodcom/README.md
+++ b/charts/prodcom/README.md
@@ -1,0 +1,130 @@
+# prodcom
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Prodcom - SSBs saksbehandlingsløsning for industriell vareproduksjon. Kjører Prodcom-appen
+(Plotly Dash) som en frittstående tjeneste i Dapla Lab / Onyxia.
+
+**Homepage:** <https://github.com/statisticsnorway/stat-prodcom>
+
+## Source Code
+
+* <https://github.com/statisticsnorway/stat-prodcom>
+* <https://github.com/statisticsnorway/dapla-lab-helm-charts-experimental>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://statisticsnorway.github.io/dapla-lab-helm-charts-library | library-chart | 4.6.1 |
+
+## Hvordan tjenesten fungerer
+
+Dette er en **app-image-tjeneste** (samme mønster som `datadoc`): charten kjører et
+ferdigbygget Docker-image direkte - den kloner *ikke* koden og installerer *ikke*
+avhengigheter ved oppstart.
+
+```
+Bruker ─▶ Istio VirtualService ("/") ─▶ Service:4180 ─▶ oauth2-proxy (sidecar)
+                                                              │  autentisering (Keycloak)
+                                                              ▼
+                                                   Dash-appen på 127.0.0.1:8061  (servert på "/")
+```
+
+- oauth2-proxy-sidecaren lytter på `4180` og videresender til appen på
+  `networking.service.port` (8061).
+- Appen serveres på rot-stien `/` (ikke bak jupyter-server-proxy). Dette styres av
+  miljøvariabelen `PRODCOM_STANDALONE=true`, som charten setter.
+- Datatilgang til Google-bøtter gis via Dapla ssbucketeer (annotasjoner på StatefulSet-en)
+  ved å velge team/tilgangsgruppe under *Data*.
+- **Prod-data leses kun i produksjonsmiljøet**: appen laster data fra produksjonsbøtta
+  bare når `DAPLA_ENVIRONMENT=PROD` (satt av charten fra `deployEnvironment`). I
+  test-clusteret (`TEST`) starter appen uten data - ingen prod-data i test.
+- Tjenesten slettes automatisk hver kveld (deleteJob, kl. 20:00 UTC = kl. 21/22 norsk
+  tid), som andre brukertjenester i Dapla Lab.
+
+## Forutsetninger (må være på plass før tjenesten fungerer)
+
+1. **Appbildet må bygges og publiseres.** Prodcom-teamet må bygge et image fra
+   `stat-prodcom` og publisere det til registeret angitt i `tjeneste.image.repository`
+   (default: `europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom`).
+   Se *Image-kontrakt* under. En ferdig `Dockerfile` er foreslått i `stat-prodcom`
+   (se medfølgende patch).
+
+2. **`dash/app.py` må støtte frittstående kjøring.** Appen er opprinnelig skrevet for
+   jupyter-server-proxy. En liten, bakoverkompatibel endring gjør at den kan serveres på
+   rot-stien og kjøre headless, og at prod-data kun lastes når `DAPLA_ENVIRONMENT=PROD`
+   (se medfølgende patch til `stat-prodcom`). Endringen påvirker ikke eksisterende bruk
+   inne i JupyterLab.
+
+3. **Datatilgang (kun produksjon).** I produksjonsmiljøet må team/tilgangsgruppen valgt
+   under *Data* ha lese/skrive-tilgang til `gs://ssb-strukt-naering-data-produkt-prod`
+   (appen leser bl.a. `vti/temp/omsetning_422/...` og `vti/inndata/nspek/...` ved
+   oppstart). I test-clusteret lastes ingen data, og tjenesten starter uavhengig av
+   bøttetilgang.
+
+## Image-kontrakt
+
+Imaget som `tjeneste.image.repository:tjeneste.image.version` peker på må:
+
+- Serve Prodcom Dash-appen over HTTP på `$PORT` (default `8061`), på rot-stien `/`.
+- Respektere `PRODCOM_STANDALONE=true` (serve på `/`, kjør headless på `0.0.0.0:$PORT`).
+- Inneholde Python-avhengighetene appen faktisk bruker, inkludert `rpy2` med **R** og
+  den SSB-interne R-pakken **Kostra** (HB-metoden kjører `importr("Kostra")`).
+  Merk: appen importerer *ikke* sentence-transformers/catboost/scikit-learn/cx-oracle -
+  disse brukes kun av pipelines utenfor `dash/` og kan utelates fra imaget.
+- Kjøre som uid `1000` med primærgruppe gid `100` (`users`): charten setter
+  `fsGroup: 100`, så volumet montert på `/home/onyxia/work` er gruppeeid av gid 100.
+- Ha en skrivbar `HOME` (`/home/onyxia`); charten peker `XDG_CACHE_HOME` til
+  `/home/onyxia/work/.cache` på det monterte volumet.
+
+## Lokal validering
+
+```bash
+helm repo add dapla-lab-library https://statisticsnorway.github.io/dapla-lab-helm-charts-library
+helm dependency build charts/prodcom
+helm lint charts/prodcom
+helm template prodcom charts/prodcom \
+  --set istio.enabled=true \
+  --set istio.hostname=prodcom.example.no \
+  --set dapla.group=<ditt-team>-developers
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.suspend | bool | `false` | Suspender (skaler til 0) tjenesten |
+| tjeneste.image.repository | string | `"europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom"` | Container-repo for det ferdigbygde Prodcom-appbildet |
+| tjeneste.image.version | string | `"latest"` | Image-tag som skal deployes |
+| tjeneste.image.pullPolicy | string | `"Always"` | Image pull policy |
+| networking.type | string | `"ClusterIP"` | Service-type |
+| networking.clusterIP | string | `"None"` | Headless service |
+| networking.service.port | int | `8061` | Porten Dash-appen lytter på i containeren |
+| ressurser.requests.cpu | string | `"500m"` | Garantert CPU |
+| ressurser.requests.memory | string | `"4Gi"` | Garantert minne (også brukt som memory limit) |
+| dapla.group | string | `""` | Team/tilgangsgruppe hvis datatilganger aktiveres (må ha tilgang til Prodcom-bøtta) |
+| dapla.sourceData.reason | string | `""` | Begrunnelse (kun for data-admins/kildedata) |
+| dapla.sourceData.requestedDuration | string | `"4h"` | Varighet på tilgang |
+| dapla.sharedBuckets | list | `[]` | Delte bøtter som skal gjøres tilgjengelige |
+| avansert.data.mountStandard | bool | `true` | Monter standardbøtter under `/buckets` |
+| security.serviceEntry.enabled | bool | `true` | Aktiver egress til eksterne tjenester |
+| security.serviceEntry.hosts | list | GCS + SSB-auth | Hoster appen får nå (egress) |
+| security.networkPolicy.enabled | bool | `false` | Aktiver network policy (ingress-policyen mot Istio rendres kun når `from` er satt) |
+| security.oauth2.provider | string | `"keycloak-oidc"` | OAuth2-provider |
+| security.oauth2.oidcIssuerUrl | string | `"overwritten-by-onyxia"` | OIDC issuer URL |
+| oidc.enabled | bool | `true` | Opprett OIDC-secret |
+| oidc.tokenExchangeUrl | string | `""` | Token exchange URL |
+| istio.enabled | bool | `false` | Aktiver Istio-ingress |
+| istio.hostname | string | `"chart-example.local"` | Ingress-hostnavn |
+| diskplass.enabled | bool | `false` | Opprett et varig lokalt filsystem (PVC). Av som standard |
+| diskplass.size | string | `"10Gi"` | Størrelse på PVC hvis aktivert |
+| deleteJob.enabled | bool | `true` | Slett tjenesten automatisk hver kveld (kl. `cronHourAtDay` UTC) |
+| deleteJob.cronHourAtDay | string | `"20"` | Time på døgnet (UTC) tjenesten slettes |
+| podDisruptionBudget.enabled | bool | `true` | Opprett PodDisruptionBudget |
+| replicaCount | int | `1` | Antall replicas |
+| serviceAccount.create | bool | `true` | Opprett service account |
+| kubernetes.enabled | bool | `false` | Gi tjenesten `view`-tilgang til eget namespace |
+| deployEnvironment | string | `"TEST"` | Miljø tjenesten deployes i |
+| environment.user | string | `"onyxia"` | Bruker i containeren |
+| environment.group | string | `"users"` | Gruppe i containeren |

--- a/charts/prodcom/README.md
+++ b/charts/prodcom/README.md
@@ -45,19 +45,28 @@ Bruker ─▶ Istio VirtualService ("/") ─▶ Service:4180 ─▶ oauth2-proxy
 
 ## Forutsetninger (må være på plass før tjenesten fungerer)
 
-1. **Appbildet må bygges og publiseres.** Prodcom-teamet må bygge et image fra
-   `stat-prodcom` og publisere det til registeret angitt i `tjeneste.image.repository`
-   (default: `europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom`).
-   Se *Image-kontrakt* under. En ferdig `Dockerfile` er foreslått i `stat-prodcom`
-   (se medfølgende patch).
+1. **Appbildet må bygges.** Workflowen *Build Prodcom service image* i `stat-prodcom`
+   (`.github/workflows/build-service-image.yaml`) bygger og publiserer imaget til
+   `europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service`
+   via `nais/docker-build-push` (team `prodcom`, allerede autorisert). Den pusher en
+   uforanderlig `<dato>-<sha>`-tag og en flytende `latest`.
 
-2. **`dash/app.py` må støtte frittstående kjøring.** Appen er opprinnelig skrevet for
-   jupyter-server-proxy. En liten, bakoverkompatibel endring gjør at den kan serveres på
-   rot-stien og kjøre headless, og at prod-data kun lastes når `DAPLA_ENVIRONMENT=PROD`
-   (se medfølgende patch til `stat-prodcom`). Endringen påvirker ikke eksisterende bruk
-   inne i JupyterLab.
+2. **Pull-tilgang fra Dapla Lab (engangs plattform-oppgave).** To porter må passeres
+   for at Dapla Lab skal kunne dra imaget:
+   - *Kyverno-policyen `restrict-image-registries`*: håndtert av charten - StatefulSet
+     og pod-template er annotert `dapla.ssb.no/service-catalog: "experimental"`, som
+     har et PolicyException (samme mekanisme som doom/pgadmin-chartene).
+   - *IAM*: Dapla Lab-clusterets node-SA har i dag kun `artifactregistry.reader` på
+     `artifact-registry-5n`-repoene. Noen med admin på NAIS GAR-repoet må gi node-SA-en
+     lesetilgang på `prodcom`-repoet i `nais-management-b3a7` (ellers ImagePullBackOff).
+     Alternativ: speile imaget inn i `artifact-registry-5n` (da trengs verken unntak
+     eller IAM-endring).
 
-3. **Datatilgang (kun produksjon).** I produksjonsmiljøet må team/tilgangsgruppen valgt
+3. **`dash/app.py`-endringen er på plass** (merget i `stat-prodcom` PR #186): appen
+   serveres på rot-stien og kjører headless når `PRODCOM_STANDALONE=true`, og prod-data
+   lastes kun når `DAPLA_ENVIRONMENT=PROD`. Eksisterende bruk i JupyterLab er uendret.
+
+4. **Datatilgang (kun produksjon).** I produksjonsmiljøet må team/tilgangsgruppen valgt
    under *Data* ha lese/skrive-tilgang til `gs://ssb-strukt-naering-data-produkt-prod`
    (appen leser bl.a. `vti/temp/omsetning_422/...` og `vti/inndata/nspek/...` ved
    oppstart). I test-clusteret lastes ingen data, og tjenesten starter uavhengig av
@@ -95,8 +104,8 @@ helm template prodcom charts/prodcom \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.suspend | bool | `false` | Suspender (skaler til 0) tjenesten |
-| tjeneste.image.repository | string | `"europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom"` | Container-repo for det ferdigbygde Prodcom-appbildet |
-| tjeneste.image.version | string | `"latest"` | Image-tag som skal deployes |
+| tjeneste.image.repository | string | `"europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service"` | Container-repo for det ferdigbygde Prodcom-appbildet |
+| tjeneste.image.version | string | `"latest"` | Image-tag som skal deployes (`latest` eller en `<dato>-<sha>`-tag fra byggejobben) |
 | tjeneste.image.pullPolicy | string | `"Always"` | Image pull policy |
 | networking.type | string | `"ClusterIP"` | Service-type |
 | networking.clusterIP | string | `"None"` | Headless service |

--- a/charts/prodcom/templates/NOTES.txt
+++ b/charts/prodcom/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Tjenesten bruker vanligvis under ett minutt på å starte opp, og er klar til bruk når
+**Åpne tjenesten**-ikonet dukker opp nederst til høyre i denne boksen.
+
+*Viktig:*
+- Prodcom-data ligger i produksjonsbøtta og leses **kun i produksjonsmiljøet**
+  (DAPLA_ENVIRONMENT=PROD). I test starter appen uten data.
+- I produksjonsmiljøet må team/tilgangsgruppen du velger under *Data* ha tilgang til
+  Prodcom-bøtta, og endringer lagres da direkte i EimerDB (`prodcombasen`).
+- All data lagres i Google-bøtter - tjenesten har ikke noe varig lokalt filsystem.
+- Tjenesten slettes automatisk hver kveld (kl. 20:00 UTC, dvs. kl. 21/22 norsk tid).

--- a/charts/prodcom/templates/configmap-oauth2proxy.yaml
+++ b/charts/prodcom/templates/configmap-oauth2proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapOAuth2" . }}

--- a/charts/prodcom/templates/delete_job.yaml
+++ b/charts/prodcom/templates/delete_job.yaml
@@ -1,0 +1,5 @@
+{{ include "library-chart.deleteJobCron" . }}
+---
+{{ include "library-chart.deleteJobRoleBinding" . }}
+---
+{{ include "library-chart.deleteJobServiceAccount" . }}

--- a/charts/prodcom/templates/networkpolicy-ingress.yaml
+++ b/charts/prodcom/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,5 @@
+{{- /* library-chart.networkPolicyIngress renders invalid YAML (and an allow-all rule)
+when networkPolicy.from is empty, so only render it when sources are configured. */}}
+{{- if .Values.security.networkPolicy.from }}
+{{ include "library-chart.networkPolicyIngress" . }}
+{{- end }}

--- a/charts/prodcom/templates/networkpolicy.yaml
+++ b/charts/prodcom/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/prodcom/templates/poddisruptionbudget.yaml
+++ b/charts/prodcom/templates/poddisruptionbudget.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.podDisruptionBudget" . }}

--- a/charts/prodcom/templates/pvc.yaml
+++ b/charts/prodcom/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/prodcom/templates/role-binding.yaml
+++ b/charts/prodcom/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/prodcom/templates/secret-oidc.yaml
+++ b/charts/prodcom/templates/secret-oidc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretOidc" . }}

--- a/charts/prodcom/templates/service.yaml
+++ b/charts/prodcom/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/prodcom/templates/serviceaccount.yaml
+++ b/charts/prodcom/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/prodcom/templates/serviceentry.yaml
+++ b/charts/prodcom/templates/serviceentry.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceentry" . }}

--- a/charts/prodcom/templates/simpleproxyclient.yaml
+++ b/charts/prodcom/templates/simpleproxyclient.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.daplaSimpleProxyClient" . }}

--- a/charts/prodcom/templates/statefulset.yaml
+++ b/charts/prodcom/templates/statefulset.yaml
@@ -1,0 +1,145 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  annotations:
+    dapla.ssb.no/enable-ssbucketeer: "true"
+    dapla.ssb.no/impersonate-group: {{ quote .Values.dapla.group }}
+    dapla.ssb.no/service-container-name: {{ quote .Chart.Name }}
+    dapla.ssb.no/access-reason: {{ quote .Values.dapla.sourceData.reason }}
+    dapla.ssb.no/requested-service-duration: {{ quote .Values.dapla.sourceData.requestedDuration }}
+    dapla.ssb.no/mount-standard-buckets: {{ quote .Values.avansert.data.mountStandard }}
+    dapla.ssb.no/mount-shared-buckets: {{ .Values.dapla.sharedBuckets | toJson | quote }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if .Values.global.suspend }}
+  replicas: 0
+{{- else }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.oidc.enabled }}
+        checksum/oidc: {{ include (print $.Template.BasePath "/secret-oidc.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      volumes:
+        - name: home
+        {{- if .Values.diskplass.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.diskplass.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - {{ include "library-chart.oauth2ProxyVolume" . | indent 10 | trim }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 256Mi
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      subdomain: {{ include "library-chart.fullname" . }}
+      hostname: prodcom
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.tjeneste.image.repository }}:{{ .Values.tjeneste.image.version }}"
+          imagePullPolicy: {{ .Values.tjeneste.image.pullPolicy }}
+          env:
+            - name: KUBERNETES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: DAPLA_ENVIRONMENT
+              value: {{ .Values.deployEnvironment }}
+            - name: DAPLA_REGION
+              value: DAPLA_LAB
+            - name: DAPLA_SERVICE
+              value: PRODCOM
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: DAPLA_GROUP_CONTEXT
+              value: {{ .Values.dapla.group | quote }}
+            - name: DAPLA_USER
+              value: {{ .Values.daplaUser | quote }}
+            - name: LABID_TOKEN_EXCHANGE_URL
+              value: http://labid.labid.svc.cluster.local/token
+            # Run the Dash app as a standalone server served at the root path (no
+            # jupyter-server-proxy prefix). Honoured by dash/app.py (see README →
+            # "Image contract" and the stat-prodcom patch).
+            - name: PRODCOM_STANDALONE
+              value: "true"
+            - name: PORT
+              value: {{ .Values.networking.service.port | quote }}
+            # Point caches at the writable work volume (mounted, group gid 100).
+            - name: HOME
+              value: /home/{{ .Values.environment.user }}
+            - name: XDG_CACHE_HOME
+              value: /home/{{ .Values.environment.user }}/work/.cache
+          envFrom:
+            {{- if .Values.oidc.enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameOidc" . }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          resources:
+            requests:
+              cpu: {{ .Values.ressurser.requests.cpu }}
+              memory: {{ .Values.ressurser.requests.memory }}
+            limits:
+              memory: {{ .Values.ressurser.requests.memory }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+        - {{ include "library-chart.oauth2ProxyPod" . | indent 10 | trim }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- $affinityYaml := include "library-chart.nodeAffinity" (dict "cpu" (.Values.ressurser.requests.cpu | trimSuffix "m") "memory" (.Values.ressurser.requests.memory | trimSuffix "Gi")) }}
+      {{- if $affinityYaml }}
+      affinity:
+        {{- $affinityYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/prodcom/templates/statefulset.yaml
+++ b/charts/prodcom/templates/statefulset.yaml
@@ -4,6 +4,9 @@ kind: StatefulSet
 metadata:
   name: {{ include "library-chart.fullname" . }}
   annotations:
+    # Unntar poden fra Kyverno-policyen restrict-image-registries, siden appbildet
+    # ligger i NAIS GAR (nais-management-b3a7) og ikke i artifact-registry-5n.
+    dapla.ssb.no/service-catalog: "experimental"
     dapla.ssb.no/enable-ssbucketeer: "true"
     dapla.ssb.no/impersonate-group: {{ quote .Values.dapla.group }}
     dapla.ssb.no/service-container-name: {{ quote .Chart.Name }}
@@ -26,6 +29,7 @@ spec:
   template:
     metadata:
       annotations:
+        dapla.ssb.no/service-catalog: "experimental"
         {{- if .Values.oidc.enabled }}
         checksum/oidc: {{ include (print $.Template.BasePath "/secret-oidc.yaml") . | sha256sum }}
         {{- end }}

--- a/charts/prodcom/templates/virtualservice.yaml
+++ b/charts/prodcom/templates/virtualservice.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.virtualservice" . }}

--- a/charts/prodcom/values.schema.json
+++ b/charts/prodcom/values.schema.json
@@ -22,7 +22,7 @@
             "repository": {
               "type": "string",
               "description": "Container-repositoriet for det ferdigbygde Prodcom-appbildet",
-              "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom",
+              "default": "europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service",
               "x-onyxia": {
                 "hidden": true
               }

--- a/charts/prodcom/values.schema.json
+++ b/charts/prodcom/values.schema.json
@@ -1,0 +1,427 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "dapla": {
+      "title": "Data",
+      "description": "Aktiver tilgang til et av dine team sine data i GCS-lagringsbøtter. I produksjonsmiljøet må gruppen ha tilgang til Prodcom-bøtta; i test starter appen uten data.",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "dapla/dapla.json"
+      }
+    },
+    "tjeneste": {
+      "title": "Prodcom",
+      "description": "Velg versjon av Prodcom-tjenesten",
+      "type": "object",
+      "properties": {
+        "image": {
+          "description": "image docker",
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Container-repositoriet for det ferdigbygde Prodcom-appbildet",
+              "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom",
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "pullPolicy": {
+              "type": "string",
+              "description": "option when pulling the docker image",
+              "default": "Always",
+              "enum": ["IfNotPresent", "Always", "Never"],
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "version": {
+              "title": "Versjon",
+              "description": "Prodcom-versjon (image-tag)",
+              "type": "string",
+              "default": "latest",
+              "pattern": "^[a-zA-Z0-9-_.:/]+$"
+            }
+          }
+        }
+      }
+    },
+    "ressurser": {
+      "title": "Ressurser",
+      "description": "Velg minimum mengde RAM og CPU som skal være tilgjengelig i tjenesten. Prodcom leser parquet-data inn i minnet og kjører R (Kostra/HB-metoden), så velg rikelig med minne.",
+      "type": "object",
+      "properties": {
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "Garantert mengde CPU. 1000 M tilsvarer én CPU-kjerne.",
+              "title": "CPU",
+              "type": "string",
+              "default": "500m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 8000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "x-onyxia": {
+                "useRegionSliderConfig": "cpu"
+              }
+            },
+            "memory": {
+              "description": "Garantert tilgjengelig minne/RAM i tjenesten",
+              "title": "Minne/RAM",
+              "type": "string",
+              "default": "4Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 128,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "x-onyxia": {
+                "useRegionSliderConfig": "memory"
+              }
+            }
+          }
+        }
+      }
+    },
+    "diskplass": {
+      "description": "Prodcom trenger ikke et lokalt filsystem – alle data lagres i GCS.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Opprett filsystem",
+          "description": "Opprett et lokalt filsystem i tjenesten",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "size": {
+          "type": "string",
+          "title": "Diskplass i filsystemet",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "diskplass/enabled"
+          }
+        }
+      }
+    },
+    "avansert": {
+      "title": "Avansert",
+      "description": "Velg avansert konfigurasjon",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "dapla/advanced.json"
+      }
+    },
+    "security": {
+      "description": "security specific configuration",
+      "type": "object",
+      "properties": {
+        "networkPolicy": {
+          "type": "object",
+          "description": "Define access policy to the service",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable network policy",
+              "description": "Only pod from the same namespace will be allowed",
+              "default": true,
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "from": {
+              "type": "array",
+              "description": "Array of source allowed to have network access to your service",
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        },
+        "serviceEntry": {
+          "type": "object",
+          "description": "Service entry to give access to external services",
+          "x-onyxia": {
+            "overwriteSchemaWith": "dapla/egress-datadoc.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable service entry",
+              "description": "Enable access to external services",
+              "default": true,
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "hosts": {
+              "type": "array",
+              "description": "Array of hosts allowed to be accessed from your service",
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        },
+        "oauth2": {
+          "type": "object",
+          "description": "OAuth2 configuration",
+          "x-onyxia": {
+            "overwriteSchemaWith": "dapla/oauth2.json"
+          },
+          "properties": {
+            "provider": {
+              "type": "string",
+              "title": "OAuth2 provider",
+              "description": "Which OAuth2 provider to use, keycloak-oidc is the only one available for now",
+              "default": "keycloak-oidc",
+              "enum": ["keycloak-oidc"],
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "oidcIssuerUrl": {
+              "type": "string",
+              "title": "OIDC issuer url",
+              "description": "Url to the OIDC issuer",
+              "default": "",
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "clientId": {
+              "type": "string",
+              "title": "Client id",
+              "description": "Client id",
+              "default": "onyxia-services",
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "authenticatedEmails": {
+              "type": "string",
+              "title": "OAuth2 authenticated emails",
+              "description": "OAuth2 authenticated emails, comma seperated",
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "{{user.email}}"
+              }
+            }
+          }
+        }
+      }
+    },
+    "istio": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress Details",
+      "x-onyxia": {
+        "hidden": false,
+        "overwriteSchemaWith": "dapla/istio.json"
+      }
+    },
+    "userAttributes": {
+      "description": "User attributes to pass into the service",
+      "type": "object",
+      "properties": {
+        "environmentVariableName": {
+          "type": "string",
+          "description": "Name of the environment variable to use",
+          "default": "OIDC_TOKEN",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "userAttribute": {
+          "type": "string",
+          "description": "The user attribute to map to the environment variable",
+          "default": "access_token",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the user attribute (will be replaced by backend)",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": ""
+          }
+        }
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Array of tolerations",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "NodeSelector",
+      "default": {},
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "dapla/nodeSelector.json"
+      }
+    },
+    "oidc": {
+      "description": "OIDC configuration",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "dapla/oidc.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "activate oidc",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tokenExchangeUrl": {
+          "type": "string",
+          "description": "token exchange url",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "secretName": {
+          "type": "string",
+          "description": "secret name",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "description": "Pod disruption budget",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable pod disruption budget",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "deleteJob": {
+      "description": "Configuration for automatic deletion of the service",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether or not to create a job to delete this release",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "cronMinuteAtDay": {
+          "type": "string",
+          "title": "Minute at day",
+          "description": "Which minute at day the job should run",
+          "default": "0",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "cronHourAtDay": {
+          "type": "string",
+          "title": "Hour at day",
+          "description": "Which hour at day the job should run",
+          "default": "20",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "imageVersion": {
+          "type": "string",
+          "title": "Version of helm-cli image",
+          "description": "Which version of the helm-cli image",
+          "default": "v1.1.0",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "clusterRoleName": {
+          "type": "string",
+          "title": "Cluster role name",
+          "description": "Which cluster role the delete job should run with",
+          "default": "onyxia-delete-job",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "deployEnvironment": {
+      "type": "string",
+      "description": "Environment in which a service is deployed",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "dapla/deployEnvironment.json"
+      }
+    },
+    "daplaUser": {
+      "type": "string",
+      "title": "Current Dapla user",
+      "description": "The currently logged in user's email address",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "{{user.email}}"
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/prodcom/values.yaml
+++ b/charts/prodcom/values.yaml
@@ -8,9 +8,11 @@ global:
 tjeneste:
   image:
     # Full container repository (without tag) for the prebuilt Prodcom app image.
-    # The Prodcom team must build and publish this image (see README.md → "Image contract").
-    repository: europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom
-    # Image tag to deploy.
+    # Built and published by stat-prodcom's "Build Prodcom service image" workflow
+    # (nais/docker-build-push, team prodcom). See README.md → "Image-kontrakt".
+    repository: europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service
+    # Image tag to deploy: "latest" (moving alias) or an immutable <date>-<sha> tag
+    # from the build workflow's Step Summary.
     version: latest
     pullPolicy: Always
 

--- a/charts/prodcom/values.yaml
+++ b/charts/prodcom/values.yaml
@@ -1,0 +1,149 @@
+# Default values for the Prodcom service.
+# The Prodcom service runs a prebuilt Plotly Dash application image (see README.md
+# for the image contract). The app is served on `networking.service.port` and fronted
+# by an oauth2-proxy sidecar (port 4180) which the Istio VirtualService routes to.
+global:
+  suspend: false
+
+tjeneste:
+  image:
+    # Full container repository (without tag) for the prebuilt Prodcom app image.
+    # The Prodcom team must build and publish this image (see README.md → "Image contract").
+    repository: europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom
+    # Image tag to deploy.
+    version: latest
+    pullPolicy: Always
+
+security:
+  networkPolicy:
+    enabled: false
+    from: []
+  serviceEntry:
+    enabled: true
+    # External hosts the app is allowed to reach (egress). Prodcom reads/writes GCS and
+    # talks to SSB auth. Overwritten by the Onyxia GUI via dapla/egress-datadoc.json.
+    hosts:
+      - "www.googleapis.com"
+      - "oauth2.googleapis.com"
+      - "storage.googleapis.com"
+      - "sts.googleapis.com"
+      - "auth.test.ssb.no"
+      - "data.ssb.no"
+      - "www.ssb.no"
+  oauth2:
+    provider: keycloak-oidc
+    oidcIssuerUrl: "overwritten-by-onyxia"
+    clientId: "onyxia-services"
+    authenticatedEmails: ""
+
+environment:
+  user: onyxia
+  group: users
+
+userAttributes:
+  environmentVariableName: OIDC_TOKEN
+  userAttribute: "access_token"
+  value: ""
+
+dapla:
+  sourceData:
+    reason: ""
+    requestedDuration: "4h"
+  # Dapla team + access group whose data accesses are activated for the service.
+  # Must be a group with access to the Prodcom production bucket
+  # (gs://ssb-strukt-naering-data-produkt-prod). See README.md.
+  group: ""
+  sharedBuckets: []
+
+oidc:
+  # Specifies whether an OIDC secret should be created
+  enabled: true
+  tokenExchangeUrl: ""
+  # The name of the secret to use. Generated from the fullname template when empty.
+  secretName: ""
+
+replicaCount: 1
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use. Generated from the fullname template when empty.
+  name: ""
+
+kubernetes:
+  enabled: false
+  role: "view"
+
+podAnnotations: {}
+
+podLabels:
+  onyxia.app: "prodcom"
+  maintained-by-team: "strukt-naering"
+
+podSecurityContext:
+  fsGroup: 100
+
+securityContext: {}
+
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    # Port the Dash app listens on inside the container.
+    port: 8061
+
+istio:
+  enabled: false
+  gateways:
+    - istio-namespace/example-gateway
+  hostname: chart-example.local
+
+# Guaranteed resources. Prodcom loads parquet data into memory and runs R via rpy2
+# (Kostra/HB-metoden), so it needs a reasonable baseline. Overwritten by the Onyxia GUI.
+ressurser:
+  requests:
+    cpu: "500m"
+    memory: "4Gi"
+
+diskplass:
+  # A local filesystem is not required: dependencies are baked into the image and all
+  # data lives in GCS. A small emptyDir is used for scratch/cache when this is disabled.
+  enabled: false
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+avansert:
+  data:
+    mountStandard: true
+
+nodeSelector: {}
+
+tolerations: []
+
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 30
+
+podDisruptionBudget:
+  enabled: true
+
+deleteJob:
+  enabled: true
+  cronMinuteAtDay: "0"
+  cronHourAtDay: "20"
+  imageVersion: "v1.1.0"
+  clusterRoleName: onyxia-delete-job
+  serviceAccount:
+    annotations: {}
+
+deployEnvironment: "TEST"
+daplaUser: ""


### PR DESCRIPTION
## Summary

This PR adds a new Helm chart, **`charts/prodcom`**, that runs the Prodcom application (`statisticsnorway/stat-prodcom` - a Plotly Dash case-handling UI for industrial production statistics) as a dedicated Dapla Lab / Onyxia service.

The chart follows the **prebuilt-app-image pattern** used by the `datadoc` chart in `dapla-lab-helm-charts-standard-test`: it runs a ready-built container image directly (no git-clone or dependency install at startup), fronted by an oauth2-proxy sidecar and an Istio VirtualService, with Dapla `ssbucketeer` annotations providing GCS access. The Dash app is served at the **root path** on port 8061.

> **Note for reviewers:** this chart is the Kubernetes/Onyxia half of the work. It depends on two changes in `statisticsnorway/stat-prodcom` (a published app image + a small backward-compatible `app.py`/`Dockerfile` change), delivered as a companion PR. The chart is complete, lints, and renders on its own, but the service will only run once that image exists.

## Changes Made

All changes are additive - a new chart directory, no existing files touched.

**Chart scaffold**
- `charts/prodcom/Chart.yaml` - chart metadata; depends on `library-chart` **4.6.1** from `dapla-lab-helm-charts-library`.
- `charts/prodcom/values.yaml` - defaults (image ref, port 8061, resources, Dapla access, egress, delete job).
- `charts/prodcom/values.schema.json` - the Onyxia service-launcher form; wires the reusable `dapla/*` overlay schemas.
- `charts/prodcom/README.md`, `templates/NOTES.txt`, `.helmignore`.

**Templates**
- `templates/statefulset.yaml` - the only bespoke template (the workload itself).
- `templates/networkpolicy-ingress.yaml` - thin wrapper **with a guard** (see below).
- Thin one-line wrappers around library helpers: `service.yaml`, `serviceentry.yaml`, `virtualservice.yaml`, `configmap-oauth2proxy.yaml`, `simpleproxyclient.yaml`, `networkpolicy.yaml`, `role-binding.yaml`, `secret-oidc.yaml`, `serviceaccount.yaml`, `pvc.yaml`, `poddisruptionbudget.yaml`, `delete_job.yaml`.

## Why These Changes Were Needed

The Prodcom team needs to run their Dash app as a first-class Dapla Lab service (launchable from the Onyxia catalog with authentication, data access, and ingress), rather than manually inside a JupyterLab session behind `jupyter-server-proxy`.

Two Prodcom-specific constraints shaped the chart:

1. **Data governance - no production data in the test environment.** The app hard-codes reads from the production bucket `gs://ssb-strukt-naering-data-produkt-prod` at import time. Those reads are gated (in the companion `stat-prodcom` PR) on `DAPLA_ENVIRONMENT=PROD`; this chart supplies that variable from `deployEnvironment` (`templates/statefulset.yaml:73`), which the Onyxia overlay pins to `TEST`/`DEV`/`PROD` per cluster. In test the service starts data-less.
2. **Standalone serving.** The app was written for `jupyter-server-proxy` (`requests_pathname_prefix = f"{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/"`). For a standalone service it must serve at `/`. The chart sets `PRODCOM_STANDALONE=true` (`statefulset.yaml:93-96`), which the companion PR's `app.py` honours.

## Implementation Details

**Request routing.** The Istio VirtualService matches host `/` and routes to the Service on port **4180** (the oauth2-proxy sidecar), which authenticates via Keycloak and proxies to the app upstream `http://127.0.0.1:8061`. The app port is `networking.service.port` (`values.yaml`), used by both the oauth2-proxy upstream and the HTTP probes (`statefulset.yaml:109-118`).

**Image reference is configurable.** Rather than hard-coding a registry (the image does not exist yet), the chart composes `tjeneste.image.repository` + `tjeneste.image.version` (`statefulset.yaml:67`), defaulting to `europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-lab-docker/onyxia/prodcom`. Documented as the "Image contract" in the README.

**Storage.** The service is stateless: dependencies are baked into the image and all data is in GCS, so `diskplass.enabled` defaults to `false` (an `emptyDir` scratch volume is mounted at `/home/onyxia/work`, with `XDG_CACHE_HOME` pointed there - `statefulset.yaml:100`).

**`networkpolicy-ingress` guard.** `library-chart` 4.6.1's `networkPolicyIngress` helper renders `- from:` followed by an empty `[]` when `security.networkPolicy.from` is empty, which is **invalid YAML** and aborts the whole release. Since Istio is always enabled on real Onyxia deploys, the naive one-line wrapper is a latent break. This chart guards it:

```diff
-{{ include "library-chart.networkPolicyIngress" . }}
+{{- /* library-chart.networkPolicyIngress renders invalid YAML (and an allow-all rule)
+when networkPolicy.from is empty, so only render it when sources are configured. */}}
+{{- if .Values.security.networkPolicy.from }}
+{{ include "library-chart.networkPolicyIngress" . }}
+{{- end }}
```

**No dead configuration.** Keys that no template consumes were deliberately omitted rather than copied from other charts: `security.allowlist` (a documented "IP protection" toggle that nothing reads - a silent security no-op), and `affinity` / `autoscaling.*` (no HPA template exists; `autoscaling.enabled=true` would also have silently broken the `suspend` feature). Suspend logic was simplified accordingly:

```diff
-{{- if not .Values.autoscaling.enabled }}
-  {{- if .Values.global.suspend }}
-  replicas: 0
-  {{- else }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
-{{- end }}
+{{- if .Values.global.suspend }}
+  replicas: 0
+{{- else }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
```

**Onyxia form.** `values.schema.json` reuses the deployed overlay schemas via `x-onyxia.overwriteSchemaWith` - `dapla/dapla.json` (team/access-group), `dapla/egress-datadoc.json` (egress), `dapla/oauth2.json`, `dapla/oidc.json`, `dapla/istio.json`, `dapla/deployEnvironment.json`, etc. - matching the `datadoc`/`marimo` charts. The visible resource sliders default to `500m` CPU / `4Gi` memory (the app loads parquet into memory and runs R via `rpy2`).

## Code Changes

**Workload - image, standalone/data env, and root-path probes** (`templates/statefulset.yaml`):

```diff
+          image: "{{ .Values.tjeneste.image.repository }}:{{ .Values.tjeneste.image.version }}"
+          env:
+            - name: DAPLA_ENVIRONMENT
+              value: {{ .Values.deployEnvironment }}      # TEST/DEV/PROD per cluster
+            - name: DAPLA_SERVICE
+              value: PRODCOM
+            - name: PRODCOM_STANDALONE                     # serve at "/", run headless
+              value: "true"
+            - name: PORT
+              value: {{ .Values.networking.service.port | quote }}   # 8061
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
```

**Dapla GCS access via ssbucketeer annotations** (`templates/statefulset.yaml:6-14`):

```diff
+  annotations:
+    dapla.ssb.no/enable-ssbucketeer: "true"
+    dapla.ssb.no/impersonate-group: {{ quote .Values.dapla.group }}
+    dapla.ssb.no/mount-standard-buckets: {{ quote .Values.avansert.data.mountStandard }}
+    dapla.ssb.no/mount-shared-buckets: {{ .Values.dapla.sharedBuckets | toJson | quote }}
```

## Testing / Validation

Validated locally with Helm 3.16.3 and the bundled `library-chart` 4.6.1:

- `helm lint --strict charts/prodcom` → passes (0 failures). Lint also validates `values.yaml` against `values.schema.json`.
- `helm template` renders cleanly for: default values (11 manifests), full config (istio + networkPolicy + dapla group → 15 manifests), `global.suspend=true` (→ `replicas: 0`), `diskplass.enabled=true` (→ PVC), `deleteJob.enabled=false` (→ no CronJob), and high resource values.
- **Regression for the guard fix:** `helm template --set istio.enabled=true --set security.networkPolicy.enabled=true` previously failed with a YAML parse error; it now renders (ingress policy correctly skipped when `from` is empty, and emitted when `from` is set).
- Negative test: a non-boolean value is rejected by the JSON schema, confirming the Onyxia form validates input.
- `yamllint` (120-col, relaxed) clean on `Chart.yaml`/`values.yaml`.
- The chart and companion patch were additionally put through a multi-agent adversarial review; the four confirmed findings (the networkPolicy YAML break, the dead `allowlist` control, an incorrect delete-time doc claim, and a misleading resource description) are fixed in this branch.

Not yet tested: a live `helm install` on a cluster (requires the Istio/`SimpleProxyClient` CRDs and the not-yet-published app image). PR CI runs `ct lint`, which the chart passes.

## Reviewer Notes

- **External dependencies (blocking runtime, not this PR):** (1) the Prodcom app image must be built and published to `tjeneste.image.repository`; (2) the companion `stat-prodcom` PR (standalone serving + `DAPLA_ENVIRONMENT`-gated data loading) must be merged. Both are documented under "Forutsetninger" / "Image-kontrakt" in `charts/prodcom/README.md`.
- **Image registry default** (`values.yaml`, `tjeneste.image.repository`) is a placeholder convention - confirm it matches where the Prodcom team will actually publish, or override it.
- **Egress** uses the shared `dapla/egress-datadoc.json` schema (GCS + SSB auth). If the app later needs additional external hosts, that must be handled via the shared egress schema.
- **Server:** the app image runs Dash's built-in (Werkzeug) server. That is acceptable for this single-user-per-instance service (oauth2-proxy restricts access to the launching user), but `datadoc` fronts its app with gunicorn - a possible future hardening.
- **Delete job** runs at `20:00 UTC` (≈ 21:00/22:00 Norwegian time); the wording in `NOTES.txt`/`README.md` now states UTC explicitly.
