### PR TITLE
prodcom: pull the service image from strukt-naering's Artifact Registry

### DIFF
--- a/charts/prodcom/Chart.yaml
+++ b/charts/prodcom/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/prodcom/README.md
+++ b/charts/prodcom/README.md
@@ -1,6 +1,6 @@
 # prodcom
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prodcom – SSBs saksbehandlingsløsning for industriell vareproduksjon (Plotly Dash-app).
 
@@ -16,6 +16,86 @@ Prodcom – SSBs saksbehandlingsløsning for industriell vareproduksjon (Plotly 
 | Repository | Name | Version |
 |------------|------|---------|
 | https://statisticsnorway.github.io/dapla-lab-helm-charts-library | library-chart | 4.6.1 |
+
+## Hvordan tjenesten fungerer
+
+Dette er en **app-image-tjeneste** (samme mønster som `datadoc`): charten kjører et
+ferdigbygget Docker-image direkte - den kloner *ikke* koden og installerer *ikke*
+avhengigheter ved oppstart.
+
+```
+Bruker ─▶ Istio VirtualService ("/") ─▶ Service:4180 ─▶ oauth2-proxy (sidecar)
+                                                              │  autentisering (Keycloak)
+                                                              ▼
+                                                   Dash-appen på 127.0.0.1:8061  (servert på "/")
+```
+
+- oauth2-proxy-sidecaren lytter på `4180` og videresender til appen på
+  `networking.service.port` (8061).
+- Appen serveres på rot-stien `/` (ikke bak jupyter-server-proxy). Dette styres av
+  miljøvariabelen `PRODCOM_STANDALONE=true`, som charten setter.
+- Datatilgang til Google-bøtter gis via Dapla ssbucketeer (annotasjoner på StatefulSet-en)
+  ved å velge team/tilgangsgruppe under *Data*.
+- **Prod-data leses kun i produksjonsmiljøet**: appen laster data fra produksjonsbøtta
+  bare når `DAPLA_ENVIRONMENT=PROD` (satt av charten fra `deployEnvironment`). I
+  test-clusteret (`TEST`) starter appen uten data - ingen prod-data i test.
+- Tjenesten slettes automatisk hver kveld (deleteJob, kl. 20:00 UTC = kl. 21/22 norsk
+  tid), som andre brukertjenester i Dapla Lab.
+
+## Forutsetninger (må være på plass før tjenesten fungerer)
+
+1. **Appbildet må bygges.** Workflowen *Build Prodcom service image* i `stat-prodcom`
+   (`.github/workflows/build-service-image.yaml`) bygger og publiserer imaget til
+   `europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/prodcom`
+   via Workload Identity Federation - eierteamets eget registry, samme modell som
+   Datadoc-editor. Den pusher en uforanderlig `<dato>-<sha>`-tag og en flytende
+   `latest`. *Engangsforutsetning*: `stat-prodcom` må stå i `artifact_registry.repos`
+   i `teams/strukt-naering/team.yaml` (statisticsnorway/terraform-ssb-dapla-teams) -
+   samme mekanisme som datadoc-repoene i `teams/dapla-metadata`.
+
+2. **Pull-tilgang fra Dapla Lab (engangs plattform-oppgave).** Clusterets node-SA må
+   ha `artifactregistry.reader` på `strukt-naering-docker`: legg repoet til i
+   `gcp_gar_repos` i `dapla-lab-iac` (prod + dev) - nøyaktig slik
+   `dapla-metadata-docker` er lagt inn for datadoc. Kyverno-policyen
+   `restrict-image-registries` tillater `europe-*-docker.pkg.dev/artifact-registry-5n/*`,
+   så charten trenger ingen `service-catalog`-annotasjon eller policy-unntak.
+
+3. **`dash/app.py`-endringen er på plass** (merget i `stat-prodcom` PR #186): appen
+   serveres på rot-stien og kjører headless når `PRODCOM_STANDALONE=true`, og prod-data
+   lastes kun når `DAPLA_ENVIRONMENT=PROD`. Eksisterende bruk i JupyterLab er uendret.
+
+4. **Datatilgang (kun produksjon).** I produksjonsmiljøet må team/tilgangsgruppen valgt
+   under *Data* ha lese/skrive-tilgang til `gs://ssb-strukt-naering-data-produkt-prod`
+   (appen leser bl.a. `vti/temp/omsetning_422/...` og `vti/inndata/nspek/...` ved
+   oppstart). I test-clusteret lastes ingen data, og tjenesten starter uavhengig av
+   bøttetilgang.
+
+## Image-kontrakt
+
+Imaget som `tjeneste.image.repository:tjeneste.image.version` peker på må:
+
+- Serve Prodcom Dash-appen over HTTP på `$PORT` (default `8061`), på rot-stien `/`.
+- Respektere `PRODCOM_STANDALONE=true` (serve på `/`, kjør headless på `0.0.0.0:$PORT`).
+- Inneholde Python-avhengighetene appen faktisk bruker, inkludert `rpy2` med **R** og
+  den SSB-interne R-pakken **Kostra** (HB-metoden kjører `importr("Kostra")`).
+  Merk: appen importerer *ikke* sentence-transformers/catboost/scikit-learn/cx-oracle -
+  disse brukes kun av pipelines utenfor `dash/` og er utelatt fra imaget.
+- Kjøre som uid `1000` med primærgruppe gid `100` (`users`): charten setter
+  `fsGroup: 100`, så volumet montert på `/home/onyxia/work` er gruppeeid av gid 100.
+- Ha en skrivbar `HOME` (`/home/onyxia`); charten peker `XDG_CACHE_HOME` til
+  `/home/onyxia/work/.cache` på det monterte volumet.
+
+## Lokal validering
+
+```bash
+helm repo add dapla-lab-library https://statisticsnorway.github.io/dapla-lab-helm-charts-library
+helm dependency build charts/prodcom
+helm lint charts/prodcom
+helm template prodcom charts/prodcom \
+  --set istio.enabled=true \
+  --set istio.hostname=prodcom.example.no \
+  --set dapla.group=<ditt-team>-developers
+```
 
 ## Values
 
@@ -86,9 +166,9 @@ Prodcom – SSBs saksbehandlingsløsning for industriell vareproduksjon (Plotly 
 | startupProbe.periodSeconds | int | `10` |  |
 | startupProbe.successThreshold | int | `1` |  |
 | startupProbe.timeoutSeconds | int | `30` |  |
-| tjeneste.image.pullPolicy | string | `"Always"` |  |
-| tjeneste.image.repository | string | `"europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service"` |  |
-| tjeneste.image.version | string | `"latest"` |  |
+| tjeneste.image.pullPolicy | string | `"Always"` | Image pull policy |
+| tjeneste.image.repository | string | `"europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/prodcom"` | Container repository (without tag) for the prebuilt Prodcom app image. Built and published to strukt-naering's own registry (the team owning the Prodcom data product) by stat-prodcom's "Build Prodcom service image" workflow - WIF push, same model as Datadoc-editor. See README.md -> "Image-kontrakt". |
+| tjeneste.image.version | string | `"latest"` | Image tag to deploy: "latest" (moving alias) or an immutable <date>-<sha> tag from the build workflow's Step Summary. |
 | tolerations | list | `[]` |  |
 | userAttributes.environmentVariableName | string | `"OIDC_TOKEN"` |  |
 | userAttributes.userAttribute | string | `"access_token"` |  |

--- a/charts/prodcom/README.md.gotmpl
+++ b/charts/prodcom/README.md.gotmpl
@@ -1,0 +1,93 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Hvordan tjenesten fungerer
+
+Dette er en **app-image-tjeneste** (samme mønster som `datadoc`): charten kjører et
+ferdigbygget Docker-image direkte - den kloner *ikke* koden og installerer *ikke*
+avhengigheter ved oppstart.
+
+```
+Bruker ─▶ Istio VirtualService ("/") ─▶ Service:4180 ─▶ oauth2-proxy (sidecar)
+                                                              │  autentisering (Keycloak)
+                                                              ▼
+                                                   Dash-appen på 127.0.0.1:8061  (servert på "/")
+```
+
+- oauth2-proxy-sidecaren lytter på `4180` og videresender til appen på
+  `networking.service.port` (8061).
+- Appen serveres på rot-stien `/` (ikke bak jupyter-server-proxy). Dette styres av
+  miljøvariabelen `PRODCOM_STANDALONE=true`, som charten setter.
+- Datatilgang til Google-bøtter gis via Dapla ssbucketeer (annotasjoner på StatefulSet-en)
+  ved å velge team/tilgangsgruppe under *Data*.
+- **Prod-data leses kun i produksjonsmiljøet**: appen laster data fra produksjonsbøtta
+  bare når `DAPLA_ENVIRONMENT=PROD` (satt av charten fra `deployEnvironment`). I
+  test-clusteret (`TEST`) starter appen uten data - ingen prod-data i test.
+- Tjenesten slettes automatisk hver kveld (deleteJob, kl. 20:00 UTC = kl. 21/22 norsk
+  tid), som andre brukertjenester i Dapla Lab.
+
+## Forutsetninger (må være på plass før tjenesten fungerer)
+
+1. **Appbildet må bygges.** Workflowen *Build Prodcom service image* i `stat-prodcom`
+   (`.github/workflows/build-service-image.yaml`) bygger og publiserer imaget til
+   `europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/prodcom`
+   via Workload Identity Federation - eierteamets eget registry, samme modell som
+   Datadoc-editor. Den pusher en uforanderlig `<dato>-<sha>`-tag og en flytende
+   `latest`. *Engangsforutsetning*: `stat-prodcom` må stå i `artifact_registry.repos`
+   i `teams/strukt-naering/team.yaml` (statisticsnorway/terraform-ssb-dapla-teams) -
+   samme mekanisme som datadoc-repoene i `teams/dapla-metadata`.
+
+2. **Pull-tilgang fra Dapla Lab (engangs plattform-oppgave).** Clusterets node-SA må
+   ha `artifactregistry.reader` på `strukt-naering-docker`: legg repoet til i
+   `gcp_gar_repos` i `dapla-lab-iac` (prod + dev) - nøyaktig slik
+   `dapla-metadata-docker` er lagt inn for datadoc. Kyverno-policyen
+   `restrict-image-registries` tillater `europe-*-docker.pkg.dev/artifact-registry-5n/*`,
+   så charten trenger ingen `service-catalog`-annotasjon eller policy-unntak.
+
+3. **`dash/app.py`-endringen er på plass** (merget i `stat-prodcom` PR #186): appen
+   serveres på rot-stien og kjører headless når `PRODCOM_STANDALONE=true`, og prod-data
+   lastes kun når `DAPLA_ENVIRONMENT=PROD`. Eksisterende bruk i JupyterLab er uendret.
+
+4. **Datatilgang (kun produksjon).** I produksjonsmiljøet må team/tilgangsgruppen valgt
+   under *Data* ha lese/skrive-tilgang til `gs://ssb-strukt-naering-data-produkt-prod`
+   (appen leser bl.a. `vti/temp/omsetning_422/...` og `vti/inndata/nspek/...` ved
+   oppstart). I test-clusteret lastes ingen data, og tjenesten starter uavhengig av
+   bøttetilgang.
+
+## Image-kontrakt
+
+Imaget som `tjeneste.image.repository:tjeneste.image.version` peker på må:
+
+- Serve Prodcom Dash-appen over HTTP på `$PORT` (default `8061`), på rot-stien `/`.
+- Respektere `PRODCOM_STANDALONE=true` (serve på `/`, kjør headless på `0.0.0.0:$PORT`).
+- Inneholde Python-avhengighetene appen faktisk bruker, inkludert `rpy2` med **R** og
+  den SSB-interne R-pakken **Kostra** (HB-metoden kjører `importr("Kostra")`).
+  Merk: appen importerer *ikke* sentence-transformers/catboost/scikit-learn/cx-oracle -
+  disse brukes kun av pipelines utenfor `dash/` og er utelatt fra imaget.
+- Kjøre som uid `1000` med primærgruppe gid `100` (`users`): charten setter
+  `fsGroup: 100`, så volumet montert på `/home/onyxia/work` er gruppeeid av gid 100.
+- Ha en skrivbar `HOME` (`/home/onyxia`); charten peker `XDG_CACHE_HOME` til
+  `/home/onyxia/work/.cache` på det monterte volumet.
+
+## Lokal validering
+
+```bash
+helm repo add dapla-lab-library https://statisticsnorway.github.io/dapla-lab-helm-charts-library
+helm dependency build charts/prodcom
+helm lint charts/prodcom
+helm template prodcom charts/prodcom \
+  --set istio.enabled=true \
+  --set istio.hostname=prodcom.example.no \
+  --set dapla.group=<ditt-team>-developers
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/prodcom/templates/statefulset.yaml
+++ b/charts/prodcom/templates/statefulset.yaml
@@ -4,9 +4,6 @@ kind: StatefulSet
 metadata:
   name: {{ include "library-chart.fullname" . }}
   annotations:
-    # Unntar poden fra Kyverno-policyen restrict-image-registries, siden appbildet
-    # ligger i NAIS GAR (nais-management-b3a7) og ikke i artifact-registry-5n.
-    dapla.ssb.no/service-catalog: "experimental"
     dapla.ssb.no/enable-ssbucketeer: "true"
     dapla.ssb.no/impersonate-group: {{ quote .Values.dapla.group }}
     dapla.ssb.no/service-container-name: {{ quote .Chart.Name }}
@@ -29,7 +26,6 @@ spec:
   template:
     metadata:
       annotations:
-        dapla.ssb.no/service-catalog: "experimental"
         {{- if .Values.oidc.enabled }}
         checksum/oidc: {{ include (print $.Template.BasePath "/secret-oidc.yaml") . | sha256sum }}
         {{- end }}

--- a/charts/prodcom/values.schema.json
+++ b/charts/prodcom/values.schema.json
@@ -22,7 +22,7 @@
             "repository": {
               "type": "string",
               "description": "Container-repositoriet for det ferdigbygde Prodcom-appbildet",
-              "default": "europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service",
+              "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/prodcom",
               "x-onyxia": {
                 "hidden": true
               }

--- a/charts/prodcom/values.yaml
+++ b/charts/prodcom/values.yaml
@@ -7,13 +7,16 @@ global:
 
 tjeneste:
   image:
-    # Full container repository (without tag) for the prebuilt Prodcom app image.
-    # Built and published by stat-prodcom's "Build Prodcom service image" workflow
-    # (nais/docker-build-push, team prodcom). See README.md → "Image-kontrakt".
-    repository: europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service
-    # Image tag to deploy: "latest" (moving alias) or an immutable <date>-<sha> tag
-    # from the build workflow's Step Summary.
+    # -- Container repository (without tag) for the prebuilt Prodcom app image.
+    # Built and published to strukt-naering's own registry (the team owning the
+    # Prodcom data product) by stat-prodcom's "Build Prodcom service image"
+    # workflow - WIF push, same model as Datadoc-editor. See README.md ->
+    # "Image-kontrakt".
+    repository: europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/prodcom
+    # -- Image tag to deploy: "latest" (moving alias) or an immutable
+    # <date>-<sha> tag from the build workflow's Step Summary.
     version: latest
+    # -- Image pull policy
     pullPolicy: Always
 
 security:


### PR DESCRIPTION
## Summary

Points the prodcom chart at the service image's home in **strukt-naering's own Artifact Registry** (`artifact-registry-5n/strukt-naering-docker/prodcom`) and removes the Kyverno-exception annotations that were only needed while the image lived in NAIS GAR. Also fixes a documentation regression: the release workflow's `helm-docs -o README.md` step erased the chart's hand-written README after the previous merge - this PR adds a `README.md.gotmpl` so regeneration preserves the docs from now on.

All prerequisites are in place - this is the last gate before the service is launchable:

- (Done) WIF push binding: terraform-ssb-dapla-teams #847 (applied by Atlantis)
- (Done) Build fixed + workflow switched to team-owned registry: stat-prodcom #189 + #190
- (Done) Cluster pull access: dapla-lab-iac #787 (`strukt-naering-docker` in `gcp_gar_repos`, prod + dev)
- (Done) Image exists: first push succeeded 2026-07-16 (run [29481443295](https://github.com/statisticsnorway/stat-prodcom/actions/runs/29481443295)) - tags `2026.07.16-07.53-72e4085` and `latest`

## Changes Made

- **`values.yaml` / `values.schema.json`:** `tjeneste.image.repository` default `europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service` → `europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/prodcom`. Image-block comments converted to helm-docs `# --` format so the generated values table gets descriptions.
- **`templates/statefulset.yaml`:** removed both `dapla.ssb.no/service-catalog: "experimental"` annotations (StatefulSet metadata + pod template) and their explanatory comment.
- **`README.md.gotmpl` (new):** helm-docs template restoring the architecture diagram, prerequisites, image contract and local-validation sections (updated for the new registry), wrapped around the generated header/requirements/values sections.
- **`README.md`:** rebuilt to match (the release workflow will canonicalize it on merge).
- **`Chart.yaml`:** version `0.1.0` → `0.2.0`.

## Why These Changes Were Needed

- **Registry move:** the image was first published to NAIS GAR, which the Dapla Lab cluster has no pull access to. Rather than a cross-project IAM grant plus a permanent Kyverno-exception dependency, the image now lives in the owning team's registry (platform-team preference, Datadoc-editor model): stat-prodcom's workflow pushes via WIF as `gh-actions-strukt-naering`, and the cluster node SA pulls via the standard `gcp_gar_repos` binding.
- **Annotation removal matters:** `artifact-registry-5n/*` passes the `restrict-image-registries` policy natively; keeping an unnecessary policy exemption on the pod would weaken the registry allowlist for no reason.
- **`README.md.gotmpl`:** `release.yaml` runs `helm-docs -o README.md`, which replaces the file with the default template unless a `.gotmpl` exists (no chart in this repo had one). The prodcom README's documentation was lost in the post-merge "Generate Helm docs" commit; the gotmpl makes the prose survive regeneration.
- **Version bump:** `chart-releaser` skips versions that already have a release - without the bump to `0.2.0`, the changed chart would never be published.

## Code Changes

**Registry default (`values.yaml`):**

```diff
-    repository: europe-north1-docker.pkg.dev/nais-management-b3a7/prodcom/stat-prodcom-service
+    repository: europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/prodcom
```

**Kyverno annotations removed (`templates/statefulset.yaml`):**

```diff
   annotations:
-    # Unntar poden fra Kyverno-policyen restrict-image-registries, siden appbildet
-    # ligger i NAIS GAR (nais-management-b3a7) og ikke i artifact-registry-5n.
-    dapla.ssb.no/service-catalog: "experimental"
     dapla.ssb.no/enable-ssbucketeer: "true"
```

```diff
     metadata:
       annotations:
-        dapla.ssb.no/service-catalog: "experimental"
         {{- if .Values.oidc.enabled }}
```

## Testing / Validation

- The image at the new path was built and pushed successfully (6 min 16 s, run [29481443295](https://github.com/statisticsnorway/stat-prodcom/actions/runs/29481443295)); the WIF auth chain was additionally validated by a no-push branch build before merging the workflow.
- Rendered-output validation (lint/kubeconform) runs in this repo's PR CI; the same templates passed in #454 - this PR only removes two annotations and changes a string default.
- End-to-end: after merge, launch *Prodcom* from the experimental catalog in Dapla Lab test; success = the Dash UI at the service URL, pod log shows `Dash is running on http://0.0.0.0:8061/`.

## Reviewer Notes

- The README.md in this PR is hand-assembled; the release workflow regenerates it from the new gotmpl on merge, which is the authoritative render.
- Rollback story: chart `0.1.0` remains published as a fallback, though its NAIS GAR default is not pullable - rolling back the registry path just means reverting `values.yaml`/`values.schema.json` to a prior image path.
- The image tag default is `latest`; users can pin the immutable `2026.07.16-07.53-72e4085` (or any later date-sha tag from the build's Step Summary) as *Versjon* in Dapla Lab.
