### PR TITLE
prodcom: flat resources layout - fixes blank Onyxia launcher

### DIFF
--- a/charts/prodcom/Chart.yaml
+++ b/charts/prodcom/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/prodcom/README.md
+++ b/charts/prodcom/README.md
@@ -141,8 +141,8 @@ helm template prodcom charts/prodcom \
 | podLabels.maintained-by-team | string | `"strukt-naering"` |  |
 | podSecurityContext.fsGroup | int | `100` |  |
 | replicaCount | int | `1` |  |
-| ressurser.requests.cpu | string | `"500m"` |  |
-| ressurser.requests.memory | string | `"4Gi"` |  |
+| resources.cpu | string | `"500m"` | Garantert CPU (requests; 1000m = one core) |
+| resources.memory | string | `"4Gi"` | Garantert minne (requests; also used as the memory limit) |
 | security.networkPolicy.enabled | bool | `false` |  |
 | security.networkPolicy.from | list | `[]` |  |
 | security.oauth2.authenticatedEmails | string | `""` |  |

--- a/charts/prodcom/templates/statefulset.yaml
+++ b/charts/prodcom/templates/statefulset.yaml
@@ -119,10 +119,10 @@ spec:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             requests:
-              cpu: {{ .Values.ressurser.requests.cpu }}
-              memory: {{ .Values.ressurser.requests.memory }}
+              cpu: {{ .Values.resources.cpu }}
+              memory: {{ .Values.resources.memory }}
             limits:
-              memory: {{ .Values.ressurser.requests.memory }}
+              memory: {{ .Values.resources.memory }}
           volumeMounts:
             - mountPath: /home/{{ .Values.environment.user }}/work
               subPath: work
@@ -134,7 +134,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $affinityYaml := include "library-chart.nodeAffinity" (dict "cpu" (.Values.ressurser.requests.cpu | trimSuffix "m") "memory" (.Values.ressurser.requests.memory | trimSuffix "Gi")) }}
+      {{- $affinityYaml := include "library-chart.nodeAffinity" (dict "cpu" (.Values.resources.cpu | trimSuffix "m") "memory" (.Values.resources.memory | trimSuffix "Gi")) }}
       {{- if $affinityYaml }}
       affinity:
         {{- $affinityYaml | nindent 8 }}

--- a/charts/prodcom/values.schema.json
+++ b/charts/prodcom/values.schema.json
@@ -31,7 +31,11 @@
               "type": "string",
               "description": "option when pulling the docker image",
               "default": "Always",
-              "enum": ["IfNotPresent", "Always", "Never"],
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ],
               "x-onyxia": {
                 "hidden": true
               }
@@ -47,43 +51,37 @@
         }
       }
     },
-    "ressurser": {
+    "resources": {
       "title": "Ressurser",
       "description": "Velg minimum mengde RAM og CPU som skal være tilgjengelig i tjenesten. Prodcom leser parquet-data inn i minnet og kjører R (Kostra/HB-metoden), så velg rikelig med minne.",
       "type": "object",
       "properties": {
-        "requests": {
-          "description": "Guaranteed resources",
-          "type": "object",
-          "properties": {
-            "cpu": {
-              "description": "Garantert mengde CPU. 1000 M tilsvarer én CPU-kjerne.",
-              "title": "CPU",
-              "type": "string",
-              "default": "500m",
-              "render": "slider",
-              "sliderMin": 50,
-              "sliderMax": 8000,
-              "sliderStep": 50,
-              "sliderUnit": "m",
-              "x-onyxia": {
-                "useRegionSliderConfig": "cpu"
-              }
-            },
-            "memory": {
-              "description": "Garantert tilgjengelig minne/RAM i tjenesten",
-              "title": "Minne/RAM",
-              "type": "string",
-              "default": "4Gi",
-              "render": "slider",
-              "sliderMin": 1,
-              "sliderMax": 128,
-              "sliderStep": 1,
-              "sliderUnit": "Gi",
-              "x-onyxia": {
-                "useRegionSliderConfig": "memory"
-              }
-            }
+        "cpu": {
+          "description": "Garantert mengde CPU. 1000 M tilsvarer én CPU-kjerne.",
+          "title": "CPU",
+          "type": "string",
+          "default": "500m",
+          "render": "slider",
+          "sliderMin": 50,
+          "sliderMax": 8000,
+          "sliderStep": 50,
+          "sliderUnit": "m",
+          "x-onyxia": {
+            "useRegionSliderConfig": "cpu"
+          }
+        },
+        "memory": {
+          "description": "Garantert tilgjengelig minne/RAM i tjenesten",
+          "title": "Minne/RAM",
+          "type": "string",
+          "default": "4Gi",
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 128,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "useRegionSliderConfig": "memory"
           }
         }
       }
@@ -197,7 +195,9 @@
               "title": "OAuth2 provider",
               "description": "Which OAuth2 provider to use, keycloak-oidc is the only one available for now",
               "default": "keycloak-oidc",
-              "enum": ["keycloak-oidc"],
+              "enum": [
+                "keycloak-oidc"
+              ],
               "x-onyxia": {
                 "hidden": true
               }

--- a/charts/prodcom/values.yaml
+++ b/charts/prodcom/values.yaml
@@ -109,12 +109,15 @@ istio:
     - istio-namespace/example-gateway
   hostname: chart-example.local
 
-# Guaranteed resources. Prodcom loads parquet data into memory and runs R via rpy2
-# (Kostra/HB-metoden), so it needs a reasonable baseline. Overwritten by the Onyxia GUI.
-ressurser:
-  requests:
-    cpu: "500m"
-    memory: "4Gi"
+# Guaranteed resources (flat cpu/memory layout: Dapla Lab's Onyxia convention, expected
+# by the ssb-plugin.js price estimator). Prodcom loads parquet data into memory and runs
+# R via rpy2 (Kostra/HB-metoden), so it needs a reasonable baseline. Overwritten by the
+# Onyxia GUI.
+resources:
+  # -- Garantert CPU (requests; 1000m = one core)
+  cpu: "500m"
+  # -- Garantert minne (requests; also used as the memory limit)
+  memory: "4Gi"
 
 diskplass:
   # A local filesystem is not required: dependencies are baked into the image and all


### PR DESCRIPTION
## Summary

Fixes the blank Onyxia launcher page for prodcom. Dapla Lab's custom `ssb-plugin.js` (price estimator) activates on any form group titled "Ressurser" and unconditionally reads `helmValues.resources.cpu`/`.memory` - the flat layout every other "Ressurser"-titled chart uses. prodcom nested them as `ressurser.requests.*`, so the plugin threw `TypeError: Cannot read properties of undefined (reading 'cpu')` (see console trace) and unmounted the page.

## Changes Made

- `values.yaml`, `values.schema.json`, `templates/statefulset.yaml`: value path `ressurser.requests.{cpu,memory}` → flat `resources.{cpu,memory}` (incl. the `library-chart.nodeAffinity` helper call). Slider config, defaults (500m/4Gi) and descriptions unchanged.
- `Chart.yaml`: `0.2.0` → `0.2.1` (chart-releaser skips released versions).

## Testing / Validation

- `helm lint --strict` clean; `helm template` renders a byte-identical StatefulSet resources block (requests 500m/4Gi, memory limit 4Gi); helm's built-in schema validation passes.
- Root cause confirmed from the browser console trace (`updatePrice (ssb-plugin.js:12:25)`) and the plugin source (statisticsnorway/onyxia, branch `ssb-assets`): the guard only fires on `data-title='Ressurser'`, and datadoc/vscode/qgis all either satisfy the flat layout or never render that title - prodcom was the only mismatch.

## Reviewer Notes

- Separate platform concern, not in this PR: `ssb-plugin.js` should guard against charts lacking `helmValues.resources` - any future chart with a visible "Ressurser" group and different layout will blank the launcher the same way.
