### PR TITLE
prodcom 0.2.2: tighten Versjon pattern, hyphen in description

### DIFF
--- a/charts/prodcom/Chart.yaml
+++ b/charts/prodcom/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prodcom
-description: Prodcom – SSBs saksbehandlingsløsning for industriell vareproduksjon (Plotly Dash-app).
+description: Prodcom - SSBs saksbehandlingsløsning for industriell vareproduksjon (Plotly Dash-app).
 icon: https://cdn-icons-png.flaticon.com/512/2933/2933116.png
 keywords:
   - Prodcom
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - name: library-chart
     version: 4.6.1

--- a/charts/prodcom/values.schema.json
+++ b/charts/prodcom/values.schema.json
@@ -45,7 +45,7 @@
               "description": "Prodcom-versjon (image-tag)",
               "type": "string",
               "default": "latest",
-              "pattern": "^[a-zA-Z0-9-_.:/]+$"
+              "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
             }
           }
         }


### PR DESCRIPTION
The image-version field previously accepted ':' and '/', so pasted input like 'prodcom:latest' passed validation and produced a broken image reference (repo:tag:tag -> ImagePullBackOff). The pattern now only accepts a plain tag. Description en-dash replaced with a hyphen.

Chart 0.2.1 -> 0.2.2.