### PR TITLE
Add nspek-noku service chart

### DIFF
--- a/charts/nspek-noku/.helmignore
+++ b/charts/nspek-noku/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/nspek-noku/Chart.yaml
+++ b/charts/nspek-noku/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: nspek-noku
+description: NSPEK/NØKU - SSBs editeringsløsning for strukturstatistikk for næringene (Plotly Dash-app).
+icon: https://cdn-icons-png.flaticon.com/512/4149/4149678.png
+keywords:
+  - Nspek
+  - Noku
+  - Dash
+  - Python
+  - Strukturstatistikk
+home: https://github.com/statisticsnorway/stat-naringer-dash
+sources:
+  - https://github.com/statisticsnorway/stat-naringer-dash
+  - https://github.com/statisticsnorway/dapla-lab-helm-charts-experimental
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+dependencies:
+  - name: library-chart
+    version: 4.6.1
+    repository: https://statisticsnorway.github.io/dapla-lab-helm-charts-library

--- a/charts/nspek-noku/README.md
+++ b/charts/nspek-noku/README.md
@@ -1,0 +1,202 @@
+# nspek-noku
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+NSPEK/NØKU - SSBs editeringsløsning for strukturstatistikk for næringene (Plotly Dash-app).
+
+**Homepage:** <https://github.com/statisticsnorway/stat-naringer-dash>
+
+## Source Code
+
+* <https://github.com/statisticsnorway/stat-naringer-dash>
+* <https://github.com/statisticsnorway/dapla-lab-helm-charts-experimental>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://statisticsnorway.github.io/dapla-lab-helm-charts-library | library-chart | 4.6.1 |
+
+## Hvordan tjenesten fungerer
+
+Dette er en **app-image-tjeneste** (samme mønster som `prodcom` og `datadoc`): charten
+kjører et ferdigbygget Docker-image direkte - den kloner *ikke* koden og installerer
+*ikke* avhengigheter ved oppstart. Appen er NSPEK/NØKU-editeringsappen fra
+`stat-naringer-dash` (`src/nspek_noku/app_nspek_noku.py`).
+
+```
+Bruker ─▶ Istio VirtualService ("/") ─▶ Service:4180 ─▶ oauth2-proxy (sidecar)
+                                                              │  autentisering (Keycloak)
+                                                              ▼
+                                                   Dash-appen på 127.0.0.1:8008  (servert på "/")
+                                                              │
+                                        Cloud SQL Auth Proxy (sidecar, localhost:5432)
+                                                              ▼
+                                              Cloud SQL Postgres (strukt-naering)
+```
+
+- oauth2-proxy-sidecaren lytter på `4180` og videresender til appen på
+  `networking.service.port` (8008).
+- Appen serveres på rot-stien `/` (ikke bak jupyter-server-proxy). Dette styres av
+  miljøvariabelen `NSPEK_NOKU_STANDALONE=true`, som charten setter.
+- **Appen krever Postgres ved oppstart**: tilkoblingspoolen åpnes ved import, mot
+  `localhost:5432` via en Cloud SQL Auth Proxy-sidecar (`--auto-iam-authn`,
+  IAM-databasebruker velges av appen ut fra `DAPLA_ENVIRONMENT`). Uten databasen
+  starter ikke tjenesten - `database.cloudSqlProxy.instance` må settes.
+- Datatilgang til Google-bøtter gis via Dapla ssbucketeer (annotasjoner på StatefulSet-en)
+  ved å velge team/tilgangsgruppe under *Data*. Appen leser og skriver
+  `/buckets/produkt/naringer/...` via de standardmonterte bøttene, og bruker
+  `/buckets/shared/vof` (delt bøtte) til VoF-fanen når den er montert.
+- Egress: charten har en egen ServiceEntry for rå TCP mot Cloud SQL-privat-IP-området
+  (port 3307, samme blokk som vscode-python-cloudsql) - mesh-en kjører
+  `outboundTrafficPolicy: REGISTRY_ONLY`, så uten den når ikke cloud-sql-proxy
+  databasen. HTTPS-egress (GCS, KLASS, auth) styres av den delte
+  `dapla/egress-datadoc.json`-skjemaet per miljø. Stilarkene fra cdn.jsdelivr.net
+  hentes av brukerens nettleser, ikke av poden, og trenger ingen egress-åpning.
+- Tjenesten slettes automatisk hver kveld (deleteJob, kl. 20:00 UTC = kl. 21/22 norsk
+  tid), som andre brukertjenester i Dapla Lab.
+
+## Forutsetninger (må være på plass før tjenesten fungerer)
+
+1. **Appbildet må bygges.** Workflowen *Build nspek-noku service image* i
+   `stat-naringer-dash` (`.github/workflows/build-service-image.yaml`) bygger og
+   publiserer imaget til
+   `europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/nspek-noku`
+   via Workload Identity Federation - eierteamets eget registry, samme modell som
+   Prodcom-tjenesten. Den pusher en uforanderlig `<dato>-<sha>`-tag og en flytende
+   `latest`. *Engangsforutsetning*: `stat-naringer-dash` må stå i
+   `artifact_registry.repos` i `teams/strukt-naering/team.yaml`
+   (statisticsnorway/terraform-ssb-dapla-teams) - samme mekanisme som `stat-prodcom`.
+
+2. **Pull-tilgang fra Dapla Lab.** Clusterets node-SA må ha `artifactregistry.reader`
+   på `strukt-naering-docker` i `gcp_gar_repos` i `dapla-lab-iac`. Denne er allerede
+   på plass (lagt inn for Prodcom-tjenesten) og gjelder hele registryet, så nye
+   image-navn under `strukt-naering-docker/` krever ingen ny endring. Kyverno-policyen
+   `restrict-image-registries` tillater `europe-*-docker.pkg.dev/artifact-registry-5n/*`,
+   så charten trenger ingen policy-unntak.
+
+3. **Standalone-endringen i appen er på plass**: appen serveres på rot-stien og kjører
+   headless når `NSPEK_NOKU_STANDALONE=true` (se stat-naringer-dash-patchen).
+   Eksisterende bruk i JupyterLab er uendret.
+
+4. **Databasetilgang.** `database.cloudSqlProxy.instance` må settes til
+   instance connection name for `strukt-naering`-databasen
+   (`<prosjekt>:<region>:<instans>`), og teamet/tilgangsgruppen må ha IAM-tilgang til
+   Cloud SQL-instansen. Appen velger IAM-databasebruker ut fra `DAPLA_ENVIRONMENT`
+   (PROD -> prod-gruppebrukeren, ellers test-gruppebrukeren). Merk: appen krever også
+   at `skjemamottak`-tabellen har rader for gjeldende årgang - en tom database gir
+   oppstartsfeil.
+
+5. **Datatilgang.** Team/tilgangsgruppen valgt under *Data* må ha lese/skrive-tilgang
+   til produktbøtta til strukt-naering (appen bruker `/buckets/produkt/naringer/...`).
+   VoF-fanen krever i tillegg at den delte VoF-bøtta legges til under delte bøtter
+   (montert på `/buckets/shared/vof`); uten den starter appen, men fanen skjules.
+
+## Image-kontrakt
+
+Imaget som `tjeneste.image.repository:tjeneste.image.version` peker på må:
+
+- Serve NSPEK/NØKU Dash-appen over HTTP på `$PORT` (default `8008`), på rot-stien `/`.
+- Respektere `NSPEK_NOKU_STANDALONE=true` (serve på `/`, kjør headless på `0.0.0.0:$PORT`).
+- Inneholde Python-avhengighetene appen faktisk bruker, inkludert `rpy2` med **R**
+  (importeres av `ssb-dash-framework` ved oppstart - Kostra-pakken trengs *ikke*).
+  Merk: Altinn/SUV/fagfunksjoner-pakkene brukes kun av pipelines utenfor appen og er
+  utelatt fra imaget.
+- Kjøre som uid `1000` med primærgruppe gid `100` (`users`): charten setter
+  `fsGroup: 100`, så volumet montert på `/home/onyxia/work` er gruppeeid av gid 100.
+  `ssb-dash-framework` skriver appens logg til `/home/onyxia/work/app.log`.
+- Ha en skrivbar `HOME` (`/home/onyxia`); charten peker `XDG_CACHE_HOME` til
+  `/home/onyxia/work/.cache` på det monterte volumet.
+
+## Lokal validering
+
+```bash
+helm repo add dapla-lab-library https://statisticsnorway.github.io/dapla-lab-helm-charts-library
+helm dependency build charts/nspek-noku
+helm lint charts/nspek-noku
+helm template nspek-noku charts/nspek-noku \
+  --set istio.enabled=true \
+  --set istio.hostname=nspek-noku.example.no \
+  --set dapla.group=<ditt-team>-developers \
+  --set database.cloudSqlProxy.instance=my-gcp-project:europe-north1:my-db-instance
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| avansert.data.mountStandard | bool | `true` |  |
+| dapla.group | string | `""` |  |
+| dapla.sharedBuckets | list | `[]` |  |
+| dapla.sourceData.reason | string | `""` |  |
+| dapla.sourceData.requestedDuration | string | `"4h"` |  |
+| daplaUser | string | `""` |  |
+| database.cloudSqlProxy.enabled | bool | `true` | Run a Cloud SQL Auth Proxy sidecar on localhost:5432. The app opens its Postgres connection pool at startup and cannot start without it. |
+| database.cloudSqlProxy.instance | string | `""` | Cloud SQL instance connection name, <project>:<region>:<instance>, for the strukt-naering database. Must be set for the service to start. |
+| deleteJob.clusterRoleName | string | `"onyxia-delete-job"` |  |
+| deleteJob.cronHourAtDay | string | `"20"` |  |
+| deleteJob.cronMinuteAtDay | string | `"0"` |  |
+| deleteJob.enabled | bool | `true` |  |
+| deleteJob.imageVersion | string | `"v1.1.0"` |  |
+| deleteJob.serviceAccount.annotations | object | `{}` |  |
+| deployEnvironment | string | `"TEST"` |  |
+| diskplass.accessMode | string | `"ReadWriteOnce"` |  |
+| diskplass.enabled | bool | `false` |  |
+| diskplass.size | string | `"10Gi"` |  |
+| environment.group | string | `"users"` |  |
+| environment.user | string | `"onyxia"` |  |
+| fullnameOverride | string | `""` |  |
+| global.suspend | bool | `false` |  |
+| imagePullSecrets | list | `[]` |  |
+| istio.enabled | bool | `false` |  |
+| istio.gateways[0] | string | `"istio-namespace/example-gateway"` |  |
+| istio.hostname | string | `"chart-example.local"` |  |
+| kubernetes.enabled | bool | `false` |  |
+| kubernetes.role | string | `"view"` |  |
+| nameOverride | string | `""` |  |
+| networking.clusterIP | string | `"None"` |  |
+| networking.service.port | int | `8008` |  |
+| networking.type | string | `"ClusterIP"` |  |
+| nodeSelector | object | `{}` |  |
+| oidc.enabled | bool | `true` |  |
+| oidc.secretName | string | `""` |  |
+| oidc.tokenExchangeUrl | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podDisruptionBudget.enabled | bool | `true` |  |
+| podLabels."onyxia.app" | string | `"nspek-noku"` |  |
+| podLabels.maintained-by-team | string | `"strukt-naering"` |  |
+| podSecurityContext.fsGroup | int | `100` |  |
+| replicaCount | int | `1` |  |
+| resources.cpu | string | `"500m"` | Garantert CPU (requests; 1000m = one core) |
+| resources.memory | string | `"4Gi"` | Garantert minne (requests; also used as the memory limit) |
+| security.networkPolicy.enabled | bool | `false` |  |
+| security.networkPolicy.from | list | `[]` |  |
+| security.oauth2.authenticatedEmails | string | `""` |  |
+| security.oauth2.clientId | string | `"onyxia-services"` |  |
+| security.oauth2.oidcIssuerUrl | string | `"overwritten-by-onyxia"` |  |
+| security.oauth2.provider | string | `"keycloak-oidc"` |  |
+| security.serviceEntry.enabled | bool | `true` |  |
+| security.serviceEntry.hosts[0] | string | `"www.googleapis.com"` |  |
+| security.serviceEntry.hosts[1] | string | `"oauth2.googleapis.com"` |  |
+| security.serviceEntry.hosts[2] | string | `"storage.googleapis.com"` |  |
+| security.serviceEntry.hosts[3] | string | `"sts.googleapis.com"` |  |
+| security.serviceEntry.hosts[4] | string | `"auth.test.ssb.no"` |  |
+| security.serviceEntry.hosts[5] | string | `"auth.ssb.no"` |  |
+| security.serviceEntry.hosts[6] | string | `"data.ssb.no"` |  |
+| security.serviceEntry.hosts[7] | string | `"www.ssb.no"` |  |
+| securityContext | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| startupProbe.failureThreshold | int | `60` |  |
+| startupProbe.initialDelaySeconds | int | `10` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `30` |  |
+| tjeneste.image.pullPolicy | string | `"Always"` | Image pull policy |
+| tjeneste.image.repository | string | `"europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/nspek-noku"` | Container repository (without tag) for the prebuilt NSPEK/NØKU app image. Built and published to strukt-naering's own registry by stat-naringer-dash's "Build nspek-noku service image" workflow - WIF push, same model as the Prodcom service. See README.md -> "Image-kontrakt". |
+| tjeneste.image.version | string | `"latest"` | Image tag to deploy: "latest" (moving alias) or an immutable <date>-<sha> tag from the build workflow's Step Summary. |
+| tolerations | list | `[]` |  |
+| userAttributes.environmentVariableName | string | `"OIDC_TOKEN"` |  |
+| userAttributes.userAttribute | string | `"access_token"` |  |
+| userAttributes.value | string | `""` |  |

--- a/charts/nspek-noku/README.md.gotmpl
+++ b/charts/nspek-noku/README.md.gotmpl
@@ -1,0 +1,117 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Hvordan tjenesten fungerer
+
+Dette er en **app-image-tjeneste** (samme mønster som `prodcom` og `datadoc`): charten
+kjører et ferdigbygget Docker-image direkte - den kloner *ikke* koden og installerer
+*ikke* avhengigheter ved oppstart. Appen er NSPEK/NØKU-editeringsappen fra
+`stat-naringer-dash` (`src/nspek_noku/app_nspek_noku.py`).
+
+```
+Bruker ─▶ Istio VirtualService ("/") ─▶ Service:4180 ─▶ oauth2-proxy (sidecar)
+                                                              │  autentisering (Keycloak)
+                                                              ▼
+                                                   Dash-appen på 127.0.0.1:8008  (servert på "/")
+                                                              │
+                                        Cloud SQL Auth Proxy (sidecar, localhost:5432)
+                                                              ▼
+                                              Cloud SQL Postgres (strukt-naering)
+```
+
+- oauth2-proxy-sidecaren lytter på `4180` og videresender til appen på
+  `networking.service.port` (8008).
+- Appen serveres på rot-stien `/` (ikke bak jupyter-server-proxy). Dette styres av
+  miljøvariabelen `NSPEK_NOKU_STANDALONE=true`, som charten setter.
+- **Appen krever Postgres ved oppstart**: tilkoblingspoolen åpnes ved import, mot
+  `localhost:5432` via en Cloud SQL Auth Proxy-sidecar (`--auto-iam-authn`,
+  IAM-databasebruker velges av appen ut fra `DAPLA_ENVIRONMENT`). Uten databasen
+  starter ikke tjenesten - `database.cloudSqlProxy.instance` må settes.
+- Datatilgang til Google-bøtter gis via Dapla ssbucketeer (annotasjoner på StatefulSet-en)
+  ved å velge team/tilgangsgruppe under *Data*. Appen leser og skriver
+  `/buckets/produkt/naringer/...` via de standardmonterte bøttene, og bruker
+  `/buckets/shared/vof` (delt bøtte) til VoF-fanen når den er montert.
+- Egress: charten har en egen ServiceEntry for rå TCP mot Cloud SQL-privat-IP-området
+  (port 3307, samme blokk som vscode-python-cloudsql) - mesh-en kjører
+  `outboundTrafficPolicy: REGISTRY_ONLY`, så uten den når ikke cloud-sql-proxy
+  databasen. HTTPS-egress (GCS, KLASS, auth) styres av den delte
+  `dapla/egress-datadoc.json`-skjemaet per miljø. Stilarkene fra cdn.jsdelivr.net
+  hentes av brukerens nettleser, ikke av poden, og trenger ingen egress-åpning.
+- Tjenesten slettes automatisk hver kveld (deleteJob, kl. 20:00 UTC = kl. 21/22 norsk
+  tid), som andre brukertjenester i Dapla Lab.
+
+## Forutsetninger (må være på plass før tjenesten fungerer)
+
+1. **Appbildet må bygges.** Workflowen *Build nspek-noku service image* i
+   `stat-naringer-dash` (`.github/workflows/build-service-image.yaml`) bygger og
+   publiserer imaget til
+   `europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/nspek-noku`
+   via Workload Identity Federation - eierteamets eget registry, samme modell som
+   Prodcom-tjenesten. Den pusher en uforanderlig `<dato>-<sha>`-tag og en flytende
+   `latest`. *Engangsforutsetning*: `stat-naringer-dash` må stå i
+   `artifact_registry.repos` i `teams/strukt-naering/team.yaml`
+   (statisticsnorway/terraform-ssb-dapla-teams) - samme mekanisme som `stat-prodcom`.
+
+2. **Pull-tilgang fra Dapla Lab.** Clusterets node-SA må ha `artifactregistry.reader`
+   på `strukt-naering-docker` i `gcp_gar_repos` i `dapla-lab-iac`. Denne er allerede
+   på plass (lagt inn for Prodcom-tjenesten) og gjelder hele registryet, så nye
+   image-navn under `strukt-naering-docker/` krever ingen ny endring. Kyverno-policyen
+   `restrict-image-registries` tillater `europe-*-docker.pkg.dev/artifact-registry-5n/*`,
+   så charten trenger ingen policy-unntak.
+
+3. **Standalone-endringen i appen er på plass**: appen serveres på rot-stien og kjører
+   headless når `NSPEK_NOKU_STANDALONE=true` (se stat-naringer-dash-patchen).
+   Eksisterende bruk i JupyterLab er uendret.
+
+4. **Databasetilgang.** `database.cloudSqlProxy.instance` må settes til
+   instance connection name for `strukt-naering`-databasen
+   (`<prosjekt>:<region>:<instans>`), og teamet/tilgangsgruppen må ha IAM-tilgang til
+   Cloud SQL-instansen. Appen velger IAM-databasebruker ut fra `DAPLA_ENVIRONMENT`
+   (PROD -> prod-gruppebrukeren, ellers test-gruppebrukeren). Merk: appen krever også
+   at `skjemamottak`-tabellen har rader for gjeldende årgang - en tom database gir
+   oppstartsfeil.
+
+5. **Datatilgang.** Team/tilgangsgruppen valgt under *Data* må ha lese/skrive-tilgang
+   til produktbøtta til strukt-naering (appen bruker `/buckets/produkt/naringer/...`).
+   VoF-fanen krever i tillegg at den delte VoF-bøtta legges til under delte bøtter
+   (montert på `/buckets/shared/vof`); uten den starter appen, men fanen skjules.
+
+## Image-kontrakt
+
+Imaget som `tjeneste.image.repository:tjeneste.image.version` peker på må:
+
+- Serve NSPEK/NØKU Dash-appen over HTTP på `$PORT` (default `8008`), på rot-stien `/`.
+- Respektere `NSPEK_NOKU_STANDALONE=true` (serve på `/`, kjør headless på `0.0.0.0:$PORT`).
+- Inneholde Python-avhengighetene appen faktisk bruker, inkludert `rpy2` med **R**
+  (importeres av `ssb-dash-framework` ved oppstart - Kostra-pakken trengs *ikke*).
+  Merk: Altinn/SUV/fagfunksjoner-pakkene brukes kun av pipelines utenfor appen og er
+  utelatt fra imaget.
+- Kjøre som uid `1000` med primærgruppe gid `100` (`users`): charten setter
+  `fsGroup: 100`, så volumet montert på `/home/onyxia/work` er gruppeeid av gid 100.
+  `ssb-dash-framework` skriver appens logg til `/home/onyxia/work/app.log`.
+- Ha en skrivbar `HOME` (`/home/onyxia`); charten peker `XDG_CACHE_HOME` til
+  `/home/onyxia/work/.cache` på det monterte volumet.
+
+## Lokal validering
+
+```bash
+helm repo add dapla-lab-library https://statisticsnorway.github.io/dapla-lab-helm-charts-library
+helm dependency build charts/nspek-noku
+helm lint charts/nspek-noku
+helm template nspek-noku charts/nspek-noku \
+  --set istio.enabled=true \
+  --set istio.hostname=nspek-noku.example.no \
+  --set dapla.group=<ditt-team>-developers \
+  --set database.cloudSqlProxy.instance=my-gcp-project:europe-north1:my-db-instance
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/nspek-noku/templates/NOTES.txt
+++ b/charts/nspek-noku/templates/NOTES.txt
@@ -1,0 +1,15 @@
+Tjenesten bruker vanligvis et par minutter på å starte opp, og er klar til bruk når
+**Åpne tjenesten**-ikonet dukker opp nederst til høyre i denne boksen.
+
+*Viktig:*
+- Appen krever databasen (Cloud SQL) ved oppstart: den starter ikke uten at
+  database-instansen er satt og at teamet/tilgangsgruppen din har IAM-tilgang til
+  `strukt-naering`-databasen.
+- Team/tilgangsgruppen du velger under *Data* må ha lese/skrive-tilgang til
+  produktbøtta til strukt-naering - appen leser og skriver
+  `/buckets/produkt/naringer/...`.
+- VoF-fanen krever i tillegg den delte bøtta med `/buckets/shared/vof` montert;
+  uten den starter appen, men fanen skjules.
+- All data lagres i Google-bøtter og Cloud SQL - tjenesten har ikke noe varig lokalt
+  filsystem.
+- Tjenesten slettes automatisk hver kveld (kl. 20:00 UTC, dvs. kl. 21/22 norsk tid).

--- a/charts/nspek-noku/templates/configmap-oauth2proxy.yaml
+++ b/charts/nspek-noku/templates/configmap-oauth2proxy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.configMapOAuth2" . }}

--- a/charts/nspek-noku/templates/delete_job.yaml
+++ b/charts/nspek-noku/templates/delete_job.yaml
@@ -1,0 +1,5 @@
+{{ include "library-chart.deleteJobCron" . }}
+---
+{{ include "library-chart.deleteJobRoleBinding" . }}
+---
+{{ include "library-chart.deleteJobServiceAccount" . }}

--- a/charts/nspek-noku/templates/networkpolicy-ingress.yaml
+++ b/charts/nspek-noku/templates/networkpolicy-ingress.yaml
@@ -1,0 +1,5 @@
+{{- /* library-chart.networkPolicyIngress renders invalid YAML (and an allow-all rule)
+when networkPolicy.from is empty, so only render it when sources are configured. */}}
+{{- if .Values.security.networkPolicy.from }}
+{{ include "library-chart.networkPolicyIngress" . }}
+{{- end }}

--- a/charts/nspek-noku/templates/networkpolicy.yaml
+++ b/charts/nspek-noku/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.networkPolicy" . }}

--- a/charts/nspek-noku/templates/poddisruptionbudget.yaml
+++ b/charts/nspek-noku/templates/poddisruptionbudget.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.podDisruptionBudget" . }}

--- a/charts/nspek-noku/templates/pvc.yaml
+++ b/charts/nspek-noku/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.persistentVolumeClaim" . }}

--- a/charts/nspek-noku/templates/role-binding.yaml
+++ b/charts/nspek-noku/templates/role-binding.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.roleBinding" . }}

--- a/charts/nspek-noku/templates/secret-oidc.yaml
+++ b/charts/nspek-noku/templates/secret-oidc.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.secretOidc" . }}

--- a/charts/nspek-noku/templates/service.yaml
+++ b/charts/nspek-noku/templates/service.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.service" . }}

--- a/charts/nspek-noku/templates/serviceaccount.yaml
+++ b/charts/nspek-noku/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.serviceAccount" . }}

--- a/charts/nspek-noku/templates/serviceentry.yaml
+++ b/charts/nspek-noku/templates/serviceentry.yaml
@@ -1,0 +1,24 @@
+{{ include "library-chart.serviceentry" . }}
+{{- if .Values.database.cloudSqlProxy.enabled }}
+---
+# Raw TCP egress to the Cloud SQL private-IP range (3307) for the cloud-sql-proxy
+# sidecar. The mesh runs outboundTrafficPolicy REGISTRY_ONLY, so without this entry
+# the proxy's connection to the instance's private IP is dropped by the Istio
+# sidecar. Same block as vscode-python-cloudsql.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: {{ include "library-chart.fullname" . }}-db-serviceentry
+spec:
+  hosts:
+    - "dummy-10.100.0.0.ssb"
+  addresses:
+    - 10.100.0.0/22
+  exportTo:
+    - "."
+  ports:
+    - name: tcp
+      number: 3307
+      protocol: tcp
+  location: MESH_EXTERNAL
+{{- end }}

--- a/charts/nspek-noku/templates/simpleproxyclient.yaml
+++ b/charts/nspek-noku/templates/simpleproxyclient.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.daplaSimpleProxyClient" . }}

--- a/charts/nspek-noku/templates/statefulset.yaml
+++ b/charts/nspek-noku/templates/statefulset.yaml
@@ -1,0 +1,175 @@
+{{- $fullName := include "library-chart.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "library-chart.fullname" . }}
+  annotations:
+    dapla.ssb.no/enable-ssbucketeer: "true"
+    dapla.ssb.no/impersonate-group: {{ quote .Values.dapla.group }}
+    dapla.ssb.no/service-container-name: {{ quote .Chart.Name }}
+    dapla.ssb.no/access-reason: {{ quote .Values.dapla.sourceData.reason }}
+    dapla.ssb.no/requested-service-duration: {{ quote .Values.dapla.sourceData.requestedDuration }}
+    dapla.ssb.no/mount-standard-buckets: {{ quote .Values.avansert.data.mountStandard }}
+    dapla.ssb.no/mount-shared-buckets: {{ .Values.dapla.sharedBuckets | toJson | quote }}
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+spec:
+{{- if .Values.global.suspend }}
+  replicas: 0
+{{- else }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  serviceName: {{ include "library-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "library-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.oidc.enabled }}
+        checksum/oidc: {{ include (print $.Template.BasePath "/secret-oidc.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "library-chart.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      volumes:
+        - name: home
+        {{- if .Values.diskplass.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.diskplass.existingClaim | default (include "library-chart.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - {{ include "library-chart.oauth2ProxyVolume" . | indent 10 | trim }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 256Mi
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "library-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      subdomain: {{ include "library-chart.fullname" . }}
+      hostname: nspek-noku
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.tjeneste.image.repository }}:{{ .Values.tjeneste.image.version }}"
+          imagePullPolicy: {{ .Values.tjeneste.image.pullPolicy }}
+          env:
+            - name: KUBERNETES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: DAPLA_ENVIRONMENT
+              value: {{ .Values.deployEnvironment }}
+            - name: DAPLA_REGION
+              value: DAPLA_LAB
+            - name: DAPLA_SERVICE
+              value: NSPEK_NOKU
+            - name: PROJECT_USER
+              value: {{ .Values.environment.user }}
+            - name: PROJECT_GROUP
+              value: {{ .Values.environment.group }}
+            - name: DAPLA_GROUP_CONTEXT
+              value: {{ .Values.dapla.group | quote }}
+            - name: DAPLA_USER
+              value: {{ .Values.daplaUser | quote }}
+            - name: LABID_TOKEN_EXCHANGE_URL
+              value: http://labid.labid.svc.cluster.local/token
+            # Run the Dash app as a standalone server served at the root path (no
+            # jupyter-server-proxy prefix). Honoured by src/nspek_noku/app_nspek_noku.py
+            # (see README → "Image-kontrakt" and the stat-naringer-dash patch).
+            - name: NSPEK_NOKU_STANDALONE
+              value: "true"
+            - name: PORT
+              value: {{ .Values.networking.service.port | quote }}
+            # Point caches at the writable work volume (mounted, group gid 100).
+            - name: HOME
+              value: /home/{{ .Values.environment.user }}
+            - name: XDG_CACHE_HOME
+              value: /home/{{ .Values.environment.user }}/work/.cache
+          envFrom:
+            {{- if .Values.oidc.enabled }}
+            - secretRef:
+                name: {{ include "library-chart.secretNameOidc" . }}
+            {{- end }}
+          # Generous probe timing: the app deliberately runs a single-threaded server
+          # (its session-state and connection-pool assumptions are not thread-safe),
+          # so a long-running callback blocks probe requests too. With Kubernetes'
+          # default 1s timeout / 3 failures, a ~25s query would get the container
+          # killed mid-editing.
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.networking.service.port }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          resources:
+            requests:
+              cpu: {{ .Values.resources.cpu }}
+              memory: {{ .Values.resources.memory }}
+            limits:
+              memory: {{ .Values.resources.memory }}
+          volumeMounts:
+            - mountPath: /home/{{ .Values.environment.user }}/work
+              subPath: work
+              name: home
+            - mountPath: /dev/shm
+              name: dshm
+        - {{ include "library-chart.oauth2ProxyPod" . | indent 10 | trim }}
+      {{- if .Values.database.cloudSqlProxy.enabled }}
+      # Cloud SQL Auth Proxy as a native sidecar (initContainer with restartPolicy
+      # Always, same pattern as vscode-python-cloudsql): the app opens its Postgres
+      # connection pool at startup and cannot start without the proxy on
+      # localhost:5432. IAM database authentication via the pod's service account.
+      initContainers:
+        - name: cloud-sql-proxy
+          restartPolicy: Always
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:latest
+          args:
+            - "--private-ip"
+            - "--auto-iam-authn"
+            - "--structured-logs"
+            - "--port=5432"
+            # Quoted: with the empty default this renders "" (the proxy then exits
+            # with a clear "missing instance connection name" in its logs) instead of
+            # a null args element the Kubernetes API rejects with a cryptic error.
+            - {{ .Values.database.cloudSqlProxy.instance | quote }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- $affinityYaml := include "library-chart.nodeAffinity" (dict "cpu" (.Values.resources.cpu | trimSuffix "m") "memory" (.Values.resources.memory | trimSuffix "Gi")) }}
+      {{- if $affinityYaml }}
+      affinity:
+        {{- $affinityYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nspek-noku/templates/virtualservice.yaml
+++ b/charts/nspek-noku/templates/virtualservice.yaml
@@ -1,0 +1,1 @@
+{{ include "library-chart.virtualservice" . }}

--- a/charts/nspek-noku/values.schema.json
+++ b/charts/nspek-noku/values.schema.json
@@ -1,0 +1,456 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "dapla": {
+      "title": "Data",
+      "description": "Aktiver tilgang til et av dine team sine data i GCS-lagringsbøtter. Gruppen må ha lese/skrive-tilgang til produktbøtta til strukt-naering (appen bruker /buckets/produkt/naringer/...).",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "dapla/dapla.json"
+      }
+    },
+    "tjeneste": {
+      "title": "NSPEK/NØKU",
+      "description": "Velg versjon av NSPEK/NØKU-tjenesten",
+      "type": "object",
+      "properties": {
+        "image": {
+          "description": "image docker",
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Container-repositoriet for det ferdigbygde NSPEK/NØKU-appbildet",
+              "default": "europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/nspek-noku",
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "pullPolicy": {
+              "type": "string",
+              "description": "option when pulling the docker image",
+              "default": "Always",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ],
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "version": {
+              "title": "Versjon",
+              "description": "NSPEK/NØKU-versjon (image-tag)",
+              "type": "string",
+              "default": "latest",
+              "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+            }
+          }
+        }
+      }
+    },
+    "database": {
+      "title": "Database",
+      "description": "Appen krever Postgres-databasen til strukt-naering (Cloud SQL) ved oppstart. Tilkoblingen går via en Cloud SQL Auth Proxy-sidecar med IAM-autentisering.",
+      "type": "object",
+      "properties": {
+        "cloudSqlProxy": {
+          "description": "Cloud SQL Auth Proxy",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Aktiver Cloud SQL Proxy",
+              "description": "Kjør en Cloud SQL Auth Proxy-sidecar på localhost:5432",
+              "default": true,
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "instance": {
+              "type": "string",
+              "title": "Database-instans",
+              "description": "Cloud SQL instance connection name, <projectid>:<region>:<instancename>, f.eks. my-gcp-project:europe-north1:my-db-instance",
+              "default": "",
+              "pattern": "^$|^[a-z][a-z0-9-]*:[a-z0-9-]+:[a-z][a-z0-9-]*$"
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "title": "Ressurser",
+      "description": "Velg minimum mengde RAM og CPU som skal være tilgjengelig i tjenesten. Appen leser parquet-data via duckdb/ibis og holder editeringsdata i minnet, så velg rikelig med minne.",
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "description": "Garantert mengde CPU. 1000 M tilsvarer én CPU-kjerne.",
+          "title": "CPU",
+          "type": "string",
+          "default": "500m",
+          "render": "slider",
+          "sliderMin": 50,
+          "sliderMax": 8000,
+          "sliderStep": 50,
+          "sliderUnit": "m",
+          "x-onyxia": {
+            "useRegionSliderConfig": "cpu"
+          }
+        },
+        "memory": {
+          "description": "Garantert tilgjengelig minne/RAM i tjenesten",
+          "title": "Minne/RAM",
+          "type": "string",
+          "default": "4Gi",
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 128,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "useRegionSliderConfig": "memory"
+          }
+        }
+      }
+    },
+    "diskplass": {
+      "description": "Tjenesten trenger ikke et lokalt filsystem - alle data lagres i GCS og Cloud SQL.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Opprett filsystem",
+          "description": "Opprett et lokalt filsystem i tjenesten",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "size": {
+          "type": "string",
+          "title": "Diskplass i filsystemet",
+          "default": "10Gi",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderStep": 1,
+          "sliderUnit": "Gi",
+          "x-onyxia": {
+            "useRegionSliderConfig": "disk"
+          },
+          "hidden": {
+            "value": false,
+            "path": "diskplass/enabled"
+          }
+        }
+      }
+    },
+    "avansert": {
+      "title": "Avansert",
+      "description": "Velg avansert konfigurasjon",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "dapla/advanced.json"
+      }
+    },
+    "security": {
+      "description": "security specific configuration",
+      "type": "object",
+      "properties": {
+        "networkPolicy": {
+          "type": "object",
+          "description": "Define access policy to the service",
+          "x-onyxia": {
+            "overwriteSchemaWith": "network-policy.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable network policy",
+              "description": "Only pod from the same namespace will be allowed",
+              "default": true,
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "from": {
+              "type": "array",
+              "description": "Array of source allowed to have network access to your service",
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        },
+        "serviceEntry": {
+          "type": "object",
+          "description": "Service entry to give access to external services",
+          "x-onyxia": {
+            "overwriteSchemaWith": "dapla/egress-datadoc.json"
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable service entry",
+              "description": "Enable access to external services",
+              "default": true,
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "hosts": {
+              "type": "array",
+              "description": "Array of hosts allowed to be accessed from your service",
+              "default": [],
+              "x-onyxia": {
+                "hidden": true
+              }
+            }
+          }
+        },
+        "oauth2": {
+          "type": "object",
+          "description": "OAuth2 configuration",
+          "x-onyxia": {
+            "overwriteSchemaWith": "dapla/oauth2.json"
+          },
+          "properties": {
+            "provider": {
+              "type": "string",
+              "title": "OAuth2 provider",
+              "description": "Which OAuth2 provider to use, keycloak-oidc is the only one available for now",
+              "default": "keycloak-oidc",
+              "enum": [
+                "keycloak-oidc"
+              ],
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "oidcIssuerUrl": {
+              "type": "string",
+              "title": "OIDC issuer url",
+              "description": "Url to the OIDC issuer",
+              "default": "",
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "clientId": {
+              "type": "string",
+              "title": "Client id",
+              "description": "Client id",
+              "default": "onyxia-services",
+              "x-onyxia": {
+                "hidden": true
+              }
+            },
+            "authenticatedEmails": {
+              "type": "string",
+              "title": "OAuth2 authenticated emails",
+              "description": "OAuth2 authenticated emails, comma seperated",
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "{{user.email}}"
+              }
+            }
+          }
+        }
+      }
+    },
+    "istio": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress Details",
+      "x-onyxia": {
+        "hidden": false,
+        "overwriteSchemaWith": "dapla/istio.json"
+      }
+    },
+    "userAttributes": {
+      "description": "User attributes to pass into the service",
+      "type": "object",
+      "properties": {
+        "environmentVariableName": {
+          "type": "string",
+          "description": "Name of the environment variable to use",
+          "default": "OIDC_TOKEN",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "userAttribute": {
+          "type": "string",
+          "description": "The user attribute to map to the environment variable",
+          "default": "access_token",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the user attribute (will be replaced by backend)",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": ""
+          }
+        }
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Array of tolerations",
+      "default": [],
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "region.tolerations",
+        "overwriteSchemaWith": "tolerations.json"
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "NodeSelector",
+      "default": {},
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "dapla/nodeSelector.json"
+      }
+    },
+    "oidc": {
+      "description": "OIDC configuration",
+      "type": "object",
+      "x-onyxia": {
+        "overwriteSchemaWith": "dapla/oidc.json"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "activate oidc",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "tokenExchangeUrl": {
+          "type": "string",
+          "description": "token exchange url",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "secretName": {
+          "type": "string",
+          "description": "secret name",
+          "default": "",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "description": "Pod disruption budget",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable pod disruption budget",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "deleteJob": {
+      "description": "Configuration for automatic deletion of the service",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether or not to create a job to delete this release",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "cronMinuteAtDay": {
+          "type": "string",
+          "title": "Minute at day",
+          "description": "Which minute at day the job should run",
+          "default": "0",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "cronHourAtDay": {
+          "type": "string",
+          "title": "Hour at day",
+          "description": "Which hour at day the job should run",
+          "default": "20",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "imageVersion": {
+          "type": "string",
+          "title": "Version of helm-cli image",
+          "description": "Which version of the helm-cli image",
+          "default": "v1.1.0",
+          "x-onyxia": {
+            "hidden": true
+          }
+        },
+        "clusterRoleName": {
+          "type": "string",
+          "title": "Cluster role name",
+          "description": "Which cluster role the delete job should run with",
+          "default": "onyxia-delete-job",
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    },
+    "deployEnvironment": {
+      "type": "string",
+      "description": "Environment in which a service is deployed",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteSchemaWith": "dapla/deployEnvironment.json"
+      }
+    },
+    "daplaUser": {
+      "type": "string",
+      "title": "Current Dapla user",
+      "description": "The currently logged in user's email address",
+      "default": "",
+      "x-onyxia": {
+        "hidden": true,
+        "overwriteDefaultWith": "{{user.email}}"
+      }
+    },
+    "global": {
+      "description": "Suspend",
+      "type": "object",
+      "properties": {
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend this service",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/nspek-noku/values.yaml
+++ b/charts/nspek-noku/values.yaml
@@ -1,0 +1,177 @@
+# Default values for the nspek-noku service.
+# The service runs a prebuilt Plotly Dash application image (see README.md for the
+# image contract): the NSPEK/NØKU editing app from statisticsnorway/stat-naringer-dash
+# (src/nspek_noku/app_nspek_noku.py). The app is served on `networking.service.port`
+# and fronted by an oauth2-proxy sidecar (port 4180) which the Istio VirtualService
+# routes to. A Cloud SQL Auth Proxy sidecar provides the Postgres database the app
+# requires at startup.
+global:
+  suspend: false
+
+tjeneste:
+  image:
+    # -- Container repository (without tag) for the prebuilt NSPEK/NØKU app image.
+    # Built and published to strukt-naering's own registry by stat-naringer-dash's
+    # "Build nspek-noku service image" workflow - WIF push, same model as the
+    # Prodcom service. See README.md -> "Image-kontrakt".
+    repository: europe-north1-docker.pkg.dev/artifact-registry-5n/strukt-naering-docker/nspek-noku
+    # -- Image tag to deploy: "latest" (moving alias) or an immutable
+    # <date>-<sha> tag from the build workflow's Step Summary.
+    version: latest
+    # -- Image pull policy
+    pullPolicy: Always
+
+database:
+  cloudSqlProxy:
+    # -- Run a Cloud SQL Auth Proxy sidecar on localhost:5432. The app opens its
+    # Postgres connection pool at startup and cannot start without it.
+    enabled: true
+    # -- Cloud SQL instance connection name, <project>:<region>:<instance>, for the
+    # strukt-naering database. Must be set for the service to start.
+    instance: ""
+
+security:
+  networkPolicy:
+    enabled: false
+    from: []
+  serviceEntry:
+    enabled: true
+    # External hosts the app is allowed to reach (egress): GCS + SSB auth and
+    # data.ssb.no for KLASS lookups. Both auth hosts are listed so helm-CLI installs
+    # work in test AND prod; the Onyxia GUI overwrites this via the environment's
+    # dapla/egress-datadoc.json (which carries the right auth host per cluster).
+    # The Bootstrap/Bootswatch stylesheets on cdn.jsdelivr.net are fetched by the
+    # user's BROWSER, not the pod, so no egress entry is needed for them.
+    hosts:
+      - "www.googleapis.com"
+      - "oauth2.googleapis.com"
+      - "storage.googleapis.com"
+      - "sts.googleapis.com"
+      - "auth.test.ssb.no"
+      - "auth.ssb.no"
+      - "data.ssb.no"
+      - "www.ssb.no"
+  oauth2:
+    provider: keycloak-oidc
+    oidcIssuerUrl: "overwritten-by-onyxia"
+    clientId: "onyxia-services"
+    authenticatedEmails: ""
+
+environment:
+  user: onyxia
+  group: users
+
+userAttributes:
+  environmentVariableName: OIDC_TOKEN
+  userAttribute: "access_token"
+  value: ""
+
+dapla:
+  sourceData:
+    reason: ""
+    requestedDuration: "4h"
+  # Dapla team + access group whose data accesses are activated for the service.
+  # Must be a group with read/write access to the strukt-naering product bucket -
+  # the app reads and writes /buckets/produkt/naringer/... via the standard bucket
+  # mounts. See README.md.
+  group: ""
+  # The VoF tab additionally needs the shared bucket with /buckets/shared/vof
+  # mounted; the app starts without it and simply hides the tab.
+  sharedBuckets: []
+
+oidc:
+  # Specifies whether an OIDC secret should be created
+  enabled: true
+  tokenExchangeUrl: ""
+  # The name of the secret to use. Generated from the fullname template when empty.
+  secretName: ""
+
+replicaCount: 1
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use. Generated from the fullname template when empty.
+  name: ""
+
+kubernetes:
+  enabled: false
+  role: "view"
+
+podAnnotations: {}
+
+podLabels:
+  onyxia.app: "nspek-noku"
+  maintained-by-team: "strukt-naering"
+
+podSecurityContext:
+  fsGroup: 100
+
+securityContext: {}
+
+networking:
+  type: ClusterIP
+  clusterIP: None
+  service:
+    # Port the Dash app listens on inside the container.
+    port: 8008
+
+istio:
+  enabled: false
+  gateways:
+    - istio-namespace/example-gateway
+  hostname: chart-example.local
+
+# Guaranteed resources (flat cpu/memory layout: Dapla Lab's Onyxia convention, expected
+# by the ssb-plugin.js price estimator). The app reads parquet data via duckdb/ibis and
+# keeps editing state in memory, so it needs a reasonable baseline. Overwritten by the
+# Onyxia GUI.
+resources:
+  # -- Garantert CPU (requests; 1000m = one core)
+  cpu: "500m"
+  # -- Garantert minne (requests; also used as the memory limit)
+  memory: "4Gi"
+
+diskplass:
+  # A local filesystem is not required: dependencies are baked into the image and all
+  # data lives in GCS/Cloud SQL. A small emptyDir is used for scratch/logs when this
+  # is disabled.
+  enabled: false
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+avansert:
+  data:
+    mountStandard: true
+
+nodeSelector: {}
+
+tolerations: []
+
+startupProbe:
+  failureThreshold: 60
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 30
+
+podDisruptionBudget:
+  enabled: true
+
+deleteJob:
+  enabled: true
+  cronMinuteAtDay: "0"
+  cronHourAtDay: "20"
+  imageVersion: "v1.1.0"
+  clusterRoleName: onyxia-delete-job
+  serviceAccount:
+    annotations: {}
+
+deployEnvironment: "TEST"
+daplaUser: ""


### PR DESCRIPTION
## Summary

Adds `charts/nspek-noku`: a Dapla Lab / Onyxia service chart for the NSPEK/NØKU
editing app (`stat-naringer-dash`, `src/nspek_noku/app_nspek_noku.py`). Same
app-image pattern as `prodcom` (chart runs a prebuilt image behind oauth2-proxy +
Istio, ssbucketeer data access, nightly delete job), extended with the pieces this
app's architecture requires: a Cloud SQL Auth Proxy sidecar, a raw-TCP
ServiceEntry for the database, and probe tuning for a deliberately
single-threaded app server.

## Changes Made

- **`charts/nspek-noku/Chart.yaml`** - new chart, version 0.1.0, library-chart
  4.6.1 dependency (same vendored tgz as prodcom).
- **`values.yaml` / `values.schema.json`** - image
  `strukt-naering-docker/nspek-noku:latest`, port 8008, flat `resources` layout,
  new `database.cloudSqlProxy.{enabled,instance}` group with a "Database" section
  in the launcher, egress via the shared `dapla/egress-datadoc.json` schema,
  tightened image-tag pattern (from prodcom 0.2.2).
- **`templates/statefulset.yaml`** - `hostname: nspek-noku`,
  `DAPLA_SERVICE=NSPEK_NOKU`, `NSPEK_NOKU_STANDALONE=true`, cloud-sql-proxy
  initContainer sidecar, explicit liveness/readiness probe tuning.
- **`templates/serviceentry.yaml`** - adds the `<fullname>-db-serviceentry`
  (TCP 3307 to the Cloud SQL private-IP range), gated on
  `database.cloudSqlProxy.enabled`.
- **`templates/NOTES.txt`, `README.md.gotmpl`, `README.md`** - service-specific
  docs (architecture, prerequisites, image contract); README generated with
  helm-docs.

## Why These Changes Were Needed

The team runs Prodcom as a Dapla Lab service and wants the same for the
NSPEK/NØKU app. The prodcom chart could not be reused as-is because this app
**requires Postgres at startup** (the connection pool opens at module import):
without a Cloud SQL proxy on `localhost:5432` and mesh egress to the database,
the pod can never become ready. It also runs a single-threaded server, which
interacts badly with default Kubernetes probe timing.

## Implementation Details

- **Cloud SQL sidecar** follows `vscode-python-cloudsql` exactly (initContainer
  with `restartPolicy: Always`, `--private-ip --auto-iam-authn --port=5432`).
  IAM database auth via the pod's service account; the app picks the IAM DB user
  from `DAPLA_ENVIRONMENT`.
- **db-ServiceEntry is required, not optional:** the mesh runs Istio
  `outboundTrafficPolicy: REGISTRY_ONLY`, so without the 3307 entry the proxy's
  connection to the instance's private IP is silently dropped - the sidecar alone
  is not enough. This is the same hardcoded block `vscode-python-cloudsql` ships.
- **`database.cloudSqlProxy.instance` defaults to empty** and must be filled in
  at launch (`<project>:<region>:<instance>`; schema pattern validates the format
  but permits empty so `helm lint` passes on defaults). The template quotes the
  arg so an unfilled field renders `""` - cloud-sql-proxy then exits with a clear
  "missing instance connection name" in its logs - instead of rendering a null
  args element that the Kubernetes API rejects with a cryptic error.
- **Probe tuning:** the app deliberately runs `threaded=False` (its
  session-state/pool assumptions are not thread-safe), so one long callback
  blocks the only request thread - including kubelet probes. Kubernetes' default
  liveness settings (1s timeout, 3 failures) would kill the container during a
  ~25s query, losing in-memory editing state. Liveness and readiness get 30s
  timeouts, 30s periods, 5 failures.
- **Egress:** the GUI uses the shared per-environment `dapla/egress-datadoc.json`
  (which carries the right Keycloak host per cluster); the chart's values default
  lists both `auth.test.ssb.no` and `auth.ssb.no` so plain helm-CLI installs work
  in either cluster. The app's cdn.jsdelivr.net stylesheets are fetched by the
  user's browser, not the pod, so no egress entry is needed for them.
- Flat `resources.cpu/memory` layout is kept - required by Dapla Lab's
  `ssb-plugin.js` price estimator (nested layouts blank the launcher; see
  prodcom 0.2.1).

## Code Changes

`templates/statefulset.yaml` - sidecar (after the containers list):

```diff
+      {{- if .Values.database.cloudSqlProxy.enabled }}
+      initContainers:
+        - name: cloud-sql-proxy
+          restartPolicy: Always
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:latest
+          args:
+            - "--private-ip"
+            - "--auto-iam-authn"
+            - "--structured-logs"
+            - "--port=5432"
+            - {{ .Values.database.cloudSqlProxy.instance | quote }}
+      {{- end }}
```

`templates/statefulset.yaml` - env deltas vs prodcom:

```diff
-            - name: DAPLA_SERVICE
-              value: PRODCOM
+            - name: DAPLA_SERVICE
+              value: NSPEK_NOKU
...
-            - name: PRODCOM_STANDALONE
+            - name: NSPEK_NOKU_STANDALONE
               value: "true"
```

`templates/statefulset.yaml` - probe tuning:

```diff
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.networking.service.port }}
+            timeoutSeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
```

`templates/serviceentry.yaml`:

```diff
 {{ include "library-chart.serviceentry" . }}
+{{- if .Values.database.cloudSqlProxy.enabled }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: {{ include "library-chart.fullname" . }}-db-serviceentry
+spec:
+  hosts:
+    - "dummy-10.100.0.0.ssb"
+  addresses:
+    - 10.100.0.0/22
+  exportTo:
+    - "."
+  ports:
+    - name: tcp
+      number: 3307
+      protocol: tcp
+  location: MESH_EXTERNAL
+{{- end }}
```

## Testing / Validation

- `helm lint --strict`: clean (including schema validation of default values).
- `helm template` with default values: renders valid manifests (quoted empty
  instance, no null args).
- `helm template` with istio + dapla.group + instance set: renders both
  ServiceEntries (library HTTPS entry + db 3307 entry), the sidecar with the
  instance name, the 8008 oauth2-proxy upstream, `hostname: nspek-noku` and the
  probe tuning.
- `README.md` regenerated from `README.md.gotmpl` with helm-docs 1.14.2 (matches
  the release workflow's behaviour).
- Not yet tested: an actual launch (blocked on the image existing - see
  prerequisites).

## Reviewer Notes

- **Merge order:** the stat-naringer-dash PR (standalone app + image build
  workflow) and the terraform-ssb-dapla-teams PR (WIF push access) must be merged
  and one image pushed from `main` before this service can start. Node-SA pull
  access on `strukt-naering-docker` is already in place (added for prodcom).
- The launcher's *Database-instans* field must be filled with the strukt-naering
  Cloud SQL instance connection name; consider hardcoding it as the schema
  default in a follow-up once confirmed, since it is fixed for this service.
- First real launch will exercise paths never run in the service context:
  Cloud SQL IAM auth chain (pod SA ↔ IAM DB user), `skjemamottak` content for
  2025/RA-0255, and bucket write access to
  `/buckets/produkt/naringer/inndata/temp/editeringsrammeverket`.
